### PR TITLE
Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language:
 env:
     # global: LATEST_TAG=1
   matrix:
-    - VERSION=2.7
-    - VERSION=3.2
-    - VERSION=3.3
-    - VERSION=3.4
+    - VERSION=2.7.9
+    - VERSION=3.2.5
+    - VERSION=3.3.5
+    - VERSION=3.4.2
 
 install:
     - source run_install.sh


### PR DESCRIPTION
Python version numbers are of the form major.minor.micro. For "normal" Linux Python builds, if you don't include the micro version number (e.g. 2.7 instead of 2.7.8), Travis will build with the latest version they have.

Currently we have in .travis.yml:

```
    - VERSION=2.7.8
    - VERSION=3.2.5
    - VERSION=3.3.5
    - VERSION=3.4.1
```

I tested with this:

```
    - VERSION=2.7
    - VERSION=3.2
    - VERSION=3.3
    - VERSION=3.4
```

But found out the get_python_environment to download Python for this OSX build requires the micro version too. So instead, let's just update for the latest Travis has right now (bumps 2.7 and 3.4):

```
    - VERSION=2.7.9
    - VERSION=3.2.5
    - VERSION=3.3.5
    - VERSION=3.4.2
```
