### PR TITLE
Run OS X tests after successful Linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ deploy:
   region: ORD
   container: wheels
   skip_cleanup: true
+  on:
+    condition: $LATEST_TAG != 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language:
   - objective-c
 
 env:
-    # global: LATEST_TAG=1
+  global: LATEST_TAG=1
   matrix:
     - VERSION=2.7.9
     - VERSION=3.2.5


### PR DESCRIPTION
Merging into a new "latest" branch.

The last build on a branch called "latest" at the python-pillow/pillow-wheels repo will be restarted after successful builds on the master branch at python-pillow/Pillow.

The Rackspace provider won't take deploys from non-master branches, but the `on: condition:` is an extra safeguard to prevent `LATEST_TAG` builds attempting to deploy. The condition can also go into master with `LATEST_TAG` commented out.

See also PR https://github.com/python-pillow/Pillow/pull/1067 and issue https://github.com/python-pillow/Pillow/issues/1065