### PR TITLE
MRG: fix building of latest OSX commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language:
   - objective-c
 
 env:
-  global: LATEST_TAG=1
+  global: PILLOW_COMMIT=origin/master
   matrix:
     - VERSION=2.7.9
     - VERSION=3.2.5
@@ -13,7 +13,9 @@ install:
     - source run_install.sh
     - get_python_environment macpython $VERSION venv
     - pip install delocate
-    - if [ -n "$LATEST_TAG" ]; then checkout_closest_tag Pillow; fi
+    - if [ -n "$PILLOW_COMMIT" ]; then
+        checkout_commit Pillow $PILLOW_COMMIT;
+      fi
     - cd Pillow
     - python setup.py bdist_wheel
     - delocate-wheel dist/*.whl
@@ -44,4 +46,4 @@ deploy:
   container: wheels
   skip_cleanup: true
   on:
-    condition: $LATEST_TAG != 1
+    condition: $PILLOW_COMMIT == latest-tag


### PR DESCRIPTION
I believe the 'latest' branch was in fact building the last tag rather the
latest commit, which I think was the intention.