### PR TITLE
MRG: fix Python 3.5 building; remove workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ script:
 
 before_deploy:
   - cd $REPO_DIR/dist
-  # Fix for https://github.com/travis-ci/travis-ci/issues/4635
-  - rvm 1.9.3 do gem install net-ssh -v 2.9.2
 
 deploy:
   provider: cloudfiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ env:
     - VERSION=3.2.5
     - VERSION=3.3.5
     - VERSION=3.4.3
+    - VERSION=3.5.0
 
 install:
     - source run_install.sh
     - get_python_environment macpython $VERSION venv
+    # Update to latest wheel package for Python 3.5
+    - pip install -U wheel
     - pip install delocate
     - if [ -n "$PILLOW_COMMIT" ]; then
         checkout_commit $REPO_DIR $PILLOW_COMMIT;


### PR DESCRIPTION
Python 3.5 build need the latest version of wheel installed into the
virtualenv.  I believe the copy of wheel that virtualenv gets depends on your
virtualenv version, not the version of wheel you have installed when you create
the virtualenv.

Also, remove workaround for fixed Rackspace deploy bug on travis-ci.