### PR TITLE
Rearrange OSX builds due to 2 at a time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,43 +26,6 @@ matrix:
       # Exclude the default Python 3.5 build
       - python: 3.5
   include:
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
     - os: osx
       language: generic
       env: MB_PYTHON_VERSION=2.7
@@ -72,6 +35,27 @@ matrix:
         - MB_PYTHON_VERSION=3.3
         # Last numpy / scipy version built for Python 3.3
         - TEST_DEPENDS="nose numpy==1.11.0 scipy==0.17.1"
+
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=2.7
+        - PLAT=i686
+        - UNICODE_WIDTH=16
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+
     - os: osx
       language: generic
       env:
@@ -80,6 +64,26 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.4
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+
     - os: osx
       language: generic
       env:


### PR DESCRIPTION
Travis has changed their open source OSX builds to only do 2 at a time. So, to speed up the overall flow, we're spacing these out so that we will generally run 2 OSX + 3 linux builds at a time. 

(note that linux builds are faster, so there's likely to be some overlap.)