### PR TITLE
Add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.7
 
     - os: linux
       env:
@@ -78,6 +82,13 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
         - PLAT=i686
 
 


### PR DESCRIPTION
* Update multibuild to latest master, which now includes the newly released Python 3.7.0 final (https://github.com/matthew-brett/multibuild/commit/7cca00d3d1d590a3ed34185ef1db1cd970c3a3a1)
* Add Python 3.7 to the Travis builds (from @jaraco's https://github.com/python-pillow/pillow-wheels/pull/86)