### PR TITLE
Changed shell commands to better match main repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,7 @@ This repository creates wheels for tagged versions of Pillow::
     cd Pillow
     git checkout <VERSION>
     cd ..
-    git add Pillow
-    git commit -a -m "<VERSION> wheels"
+    git commit -m "Pillow -> <VERSION>" Pillow
     git push
 
 .. image:: https://img.shields.io/travis/python-pillow/pillow-wheels/latest.svg


### PR DESCRIPTION
This matches https://github.com/python-pillow/Pillow/blob/master/RELEASING.md#mac-and-linux better, including https://github.com/python-pillow/Pillow/pull/3321. Also, the `-a` git flags adds all modified files. This just adds Pillow instead.