### PR TITLE
Disable SSE4.1 for libwebp to update travis osx_image to 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-cov numpy scipy"
+      - MACOSX_DEPLOYMENT_TARGET=10.10
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with
       # travis encrypt -r python-pillow/pillow-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
@@ -17,7 +18,7 @@ python: 3.5
 sudo: required
 dist: trusty
 services: docker
-osx_image: xcode6.4
+osx_image: xcode9.4
 
 matrix:
   exclude:

--- a/config.sh
+++ b/config.sh
@@ -34,11 +34,17 @@ function pre_build {
         install_name_tool -id $BUILD_PREFIX/lib/libopenjp2.7.dylib $BUILD_PREFIX/lib/libopenjp2.2.1.0.dylib
     fi
     build_lcms2
-    build_libwebp
     if [ -n "$IS_OSX" ]; then
+        # Custom libwebp build to allow building on OS X 10.10 and 10.11
+        build_giflib
+        build_simple libwebp $LIBWEBP_VERSION \
+            https://storage.googleapis.com/downloads.webmproject.org/releases/webp tar.gz \
+            --enable-libwebpmux --enable-libwebpdemux --disable-sse4.1
+        
         # Custom freetype build
         build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
     else
+        build_libwebp
         build_freetype
     fi
 }


### PR DESCRIPTION
Resolves #96. Alternative to #104

The custom `build_libwebp` is customised from https://github.com/matthew-brett/multibuild/blob/6713093b24c014168d282df1111ed6cdc141da55/library_builders.sh#L198, removing the libraries already built, and adding `--disable-sse4.1`