### PR TITLE
Pin wheel to 0.31.1 to work around API break in 0.32.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
-      - TEST_DEPENDS="pytest pytest-cov numpy scipy"
+      - TEST_DEPENDS="pytest pytest-cov numpy scipy wheel==0.31.1"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with
       # travis encrypt -r python-pillow/pillow-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>

--- a/config.sh
+++ b/config.sh
@@ -69,3 +69,16 @@ function run_tests {
     fi
     return $ret
 }
+
+if [ -n "$IS_OSX" ]; then
+	function before_install {
+		# Custom before_install to temporarily pin wheel to 0.31.1
+		brew cask uninstall oclint || true
+		export CC=clang
+		export CXX=clang++
+		get_macpython_environment $MB_PYTHON_VERSION venv
+		source venv/bin/activate
+		pip install --upgrade pip
+		pip install wheel==0.31.1
+	}
+fi


### PR DESCRIPTION
Here's a rebuild of master, which now fails:

* https://travis-ci.org/python-pillow/pillow-wheels/builds/435068720

See:
* https://github.com/matthew-brett/multibuild/issues/202
* https://github.com/pypa/wheel/issues/255
