### PR TITLE
Resolved auditwheel error by further pinning of wheel to 0.31.1

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -70,9 +70,9 @@ function run_tests {
     return $ret
 }
 
+# Custom functions to temporarily pin wheel to 0.31.1
 if [ -n "$IS_OSX" ]; then
 	function before_install {
-		# Custom before_install to temporarily pin wheel to 0.31.1
 		brew cask uninstall oclint || true
 		export CC=clang
 		export CXX=clang++
@@ -81,4 +81,21 @@ if [ -n "$IS_OSX" ]; then
 		pip install --upgrade pip
 		pip install wheel==0.31.1
 	}
+else
+	function build_wheel_cmd {
+		local cmd=${1:-pip_wheel_cmd}
+		local repo_dir=${2:-$REPO_DIR}
+		[ -z "$repo_dir" ] && echo "repo_dir not defined" && exit 1
+		local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
+		start_spinner
+		if [ -n "$(is_function "pre_build")" ]; then pre_build; fi
+		stop_spinner
+		if [ -n "$BUILD_DEPENDS" ]; then
+			pip install $(pip_opts) $BUILD_DEPENDS
+		fi
+		/opt/python/cp36-cp36m/bin/pip3 install wheel==0.31.1
+		(cd $repo_dir && $cmd $wheelhouse)
+		pip show wheel
+		repair_wheelhouse $wheelhouse
+	}	
 fi


### PR DESCRIPTION
I have found new errors generated on Linux by the upgrade to wheel 0.32, so this is a sequel to #100.

https://travis-ci.org/python-pillow/pillow-wheels/jobs/435427307#L4860

```
Traceback (most recent call last):
  File "/usr/local/bin/auditwheel", line 11, in <module>
    sys.exit(main())
  File "/opt/_internal/cpython-3.6.6/lib/python3.6/site-packages/auditwheel/main.py", line 49, in main
    rval = args.func(args, p)
  File "/opt/_internal/cpython-3.6.6/lib/python3.6/site-packages/auditwheel/main_repair.py", line 43, in execute
    from .repair import repair_wheel
  File "/opt/_internal/cpython-3.6.6/lib/python3.6/site-packages/auditwheel/repair.py", line 13, in <module>
    from .wheeltools import InWheelCtx, add_platforms
  File "/opt/_internal/cpython-3.6.6/lib/python3.6/site-packages/auditwheel/wheeltools.py", line 14, in <module>
    from wheel.util import urlsafe_b64encode, open_for_csv, native  # type: ignore
ImportError: cannot import name 'open_for_csv'
```

`auditwheel` uses Python 3, so I've pinned the wheel for Python 3 using another custom function.