### PR TITLE
Updated travis osx_image to 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-cov numpy scipy"
+      - MACOSX_DEPLOYMENT_TARGET=10.10
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with
       # travis encrypt -r python-pillow/pillow-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
@@ -17,7 +18,7 @@ python: 3.5
 sudo: required
 dist: trusty
 services: docker
-osx_image: xcode6.4
+osx_image: xcode9.4
 
 matrix:
   exclude:

--- a/config.sh
+++ b/config.sh
@@ -34,7 +34,19 @@ function pre_build {
         install_name_tool -id $BUILD_PREFIX/lib/libopenjp2.7.dylib $BUILD_PREFIX/lib/libopenjp2.2.1.0.dylib
     fi
     build_lcms2
+
+    if [ -n "$IS_OSX" ]; then
+        # Custom flags to allow building on OS X 10.10 and 10.11
+        build_giflib
+        
+        ORIGINAL_CPPFLAGS=$CPPFLAGS
+        CPPFLAGS=""
+    fi
     build_libwebp
+    if [ -n "$IS_OSX" ]; then
+        CPPFLAGS=$ORIGINAL_CPPFLAGS
+    fi
+
     if [ -n "$IS_OSX" ]; then
         # Custom freetype build
         build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no


### PR DESCRIPTION
Resolves #96. Alternative to #97

`build_giflib` is the only dependency from https://github.com/matthew-brett/multibuild/blob/6713093b24c014168d282df1111ed6cdc141da55/library_builders.sh#L198 that is not already built.

On current master, the libwebp build reports '[checking whether clang supports -msse4.1... no](https://travis-ci.org/python-pillow/pillow-wheels/jobs/440600001#L3737)'. When updating `osx_image`, errors related to sse4.1 then appear. #97 solves this by disabling sse4.1. The flags change in this PR causes the libwebp build to report '[checking whether clang supports -msse4.1... yes](https://travis-ci.org/python-pillow/pillow-wheels/jobs/440973130#L3696)', and then continue without error when `osx_image` is updated.