### PR TITLE
'sudo: required' no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 language: python
 # Default Python version is usually 2.7
 python: 3.5
-sudo: required
 dist: trusty
 services: docker
 osx_image: xcode6.4


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration