### PR TITLE
Removed scipy as test dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
-      - TEST_DEPENDS="pytest pytest-cov numpy scipy"
+      - TEST_DEPENDS="pytest pytest-cov numpy"
       - MACOSX_DEPLOYMENT_TARGET=10.10
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/3087 removed test_scipy.py, meaning that scipy is no longer used in the tests.