### PR TITLE
Include both multibuild and jpeg default CFLAGS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -24,7 +24,13 @@ function pre_build {
         # Update to latest zlib for OSX build
         build_new_zlib
     fi
+    
+    # Custom flags to include both multibuild and jpeg defaults
+    ORIGINAL_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -g -O2"
     build_jpeg
+    CFLAGS=$ORIGINAL_CFLAGS
+    
     build_tiff
     build_libpng
     build_openjpeg


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/3441

Here are speed comparisons between the different Pillow versions installed from pip, a local wheel file of 6.0.0 (the only differences between this and pip 6.0.0 should be Freetype, as these wheels were created on TravisCI), and a local wheel with this PR.

Pillow | 2.7 | 3.7
-- | -- | --
5.0.0 | 2.01 | 1.71
5.1.0 | 4.3  | 1.59
5.2.0 | 4.3  | 4.63
5.3.0 | 4.3  | 4.61
5.4.0 | 4.38 | 4.56
5.4.1 | 4.37 | 4.58
6.0.0 | 4.36 | 4.61
6.0.0 Local | 4.38 | 4.64
6.0.0 Local With CFLAGS fix | 2.11 | 2.22