### PR TITLE
Include both multibuild and libwebp default CFLAGS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -43,7 +43,9 @@ function pre_build {
         ORIGINAL_CPPFLAGS=$CPPFLAGS
         CPPFLAGS=""
     fi
+    CFLAGS="$CFLAGS -O3 -DNDEBUG"
     build_libwebp
+    CFLAGS=$ORIGINAL_CFLAGS
     if [ -n "$IS_OSX" ]; then
         CPPFLAGS=$ORIGINAL_CPPFLAGS
     fi


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/4040. libwebp equivalent of #117

Takes the new CFLAGs from https://github.com/webmproject/libwebp/blob/0e48d889eb90363c6ebf8ea276bae4d892f9d3c0/makefile.unix#L112

Testing with the following code -

```python
from PIL import Image
import time
im = Image.open('hopper.jpg')
start = time.time()
for i in range(0, 1000):
    im.save('out.webp')
print(time.time() - start)
```

Speed | macOS | Linux
-- | -- | --
[Timer script](https://github.com/radarhere/pillow-wheels/commit/fdd4d15c6bd68f7d9f34b2e16964846224ce6852) | [19.58s](https://travis-ci.org/radarhere/pillow-wheels/jobs/579776646#L4212) | [22.19s](https://travis-ci.org/radarhere/pillow-wheels/jobs/579776647#L4971)
[Fix](https://github.com/radarhere/pillow-wheels/commit/2199bcecbc57c8236501c89f147b56b6c6158a79) | [5.34s](https://travis-ci.org/radarhere/pillow-wheels/jobs/579776834#L4213)  | [3.54s](https://travis-ci.org/radarhere/pillow-wheels/jobs/579776835#L4968)