### PR TITLE
Fixed updating to latest from non-master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,8 +220,8 @@ before_install:
 
 install:
     # Maybe get and clean and patch source
+    - if [[ -n "$LATEST" ]]; then BUILD_COMMIT=master; fi
     - clean_code $REPO_DIR $BUILD_COMMIT
-    - if [[ -n "$LATEST" ]]; then git submodule update --remote --merge $REPO_DIR; fi
     - build_wheel $REPO_DIR $PLAT
 
 script:


### PR DESCRIPTION
https://github.com/python-pillow/pillow-wheels/blob/9e7dcea7395b4b30fc78da7b197c20ed380a0130/.travis.yml#L223-L224

`clean_code` actually already updates - https://github.com/matthew-brett/multibuild/blob/160edd796c25c0aa400b73ce79cecfa1758c181e/common_utils.sh#L211

So changing `BUILD_COMMIT` is an alternative to using the submodule command - and it avoids the merge conflicts that are causing pillow-wheels to fail at the moment, [caused by 6.2.1.](https://github.com/python-pillow/Pillow/issues/4152#issuecomment-544647530)