### PR TITLE
Updated multibuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
-        - MB_PYTHON_OSX_VER=10.9
 
     - name: "3.7 Xenial"
       os: linux
@@ -132,7 +131,6 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
-        - MB_PYTHON_OSX_VER=10.9
         - LATEST="true"
 
     - name: "3.7 Xenial latest"


### PR DESCRIPTION
Moves multibuild back in line with master.

Stops specifying ``MB_PYTHON_OSX_VER``, added in #127, now that the updated multibuild has good defaults for this - https://github.com/matthew-brett/multibuild/pull/275