### PR TITLE
Updated bzip2 to 1.0.8 for Linux

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -14,6 +14,7 @@ TIFF_VERSION=4.1.0
 LCMS2_VERSION=2.9
 GIFLIB_VERSION=5.1.4
 LIBWEBP_VERSION=1.0.3
+BZIP2_VERSION=1.0.8
 
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
@@ -50,12 +51,18 @@ function pre_build {
         CPPFLAGS=$ORIGINAL_CPPFLAGS
     fi
 
+    # freetype
+    freetype_args=""
     if [ -n "$IS_OSX" ]; then
-        # Custom freetype build
-        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
+        freetype_args="--with-harfbuzz=no"
     else
-        build_freetype
+        # bzip2
+        fetch_unpack https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
+        (cd bzip2-${BZIP2_VERSION} \
+            && make -f Makefile-libbz2_so \
+            && make install PREFIX=$BUILD_PREFIX)
     fi
+    build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz $freetype_args
 }
 
 function run_tests_in_repo {


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/4234

The [default bzip2 version is 1.0.6](https://github.com/matthew-brett/multibuild/blob/88a0b6f0eb770cf9f95792d66410e7696ce3d384/library_builders.sh#L16). This PR updates that to 1.0.8. macOS is avoided for now due to a compilation error.

I'm using custom code instead of `build_bzip2` because the URL in the multibuild code does not have access to the 1.0.8 version - see https://github.com/matthew-brett/multibuild/pull/282 for my PR to fix that