### PR TITLE
Changed Travis osx_image to 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: python
 python: 3.5
 dist: xenial
 services: docker
-osx_image: xcode9.4
+osx_image: xcode9.3
 
 matrix:
   exclude:


### PR DESCRIPTION
Resolves #133

For whatever reason, fixes the failing Python 3.8 macOS tests in master.