### PR TITLE
Removed customisation of bzip2 build

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -51,18 +51,12 @@ function pre_build {
         CPPFLAGS=$ORIGINAL_CPPFLAGS
     fi
 
-    # freetype
-    freetype_args=""
     if [ -n "$IS_OSX" ]; then
-        freetype_args="--with-harfbuzz=no"
+        # Custom freetype build
+        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
     else
-        # bzip2
-        fetch_unpack https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
-        (cd bzip2-${BZIP2_VERSION} \
-            && make -f Makefile-libbz2_so \
-            && make install PREFIX=$BUILD_PREFIX)
+        build_freetype
     fi
-    build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz $freetype_args
 }
 
 function run_tests_in_repo {


### PR DESCRIPTION
Since #138 updated multibuild, https://github.com/matthew-brett/multibuild/pull/282 is now included. This updates the bzip2 download URL to allow for bzip2 versions other than 1.0.6.

As noted in #131, the absence of this required custom code. Now, the custom code introduced by #131 can be removed, with multibuild's [`build_freetype`](https://github.com/matthew-brett/multibuild/blob/6b0ddb5281f59d976c8026c082c9d73faf274790/library_builders.sh#L206-L208) automatically running [`build_bzip2`](https://github.com/matthew-brett/multibuild/blob/6b0ddb5281f59d976c8026c082c9d73faf274790/library_builders.sh#L138-L146)