### PR TITLE
Fix Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
       - secure: "ky76goiK6n4k8V9/uG340GSFVwmjE7G76l9xbhhGZkcph4eTwN5VRM/tqyJvlNs/HZOhKSILfyGBeaG8qf7gHmwr0touPT+EjWn4TNV8iyVj75ZshgRE9DuaIAfdH89gW2m+BmvBDyzi0JE3KVCu55NcGm8h7Ecl6nmQ/c2iROY="
 
 language: python
-# Default Python version is usually 2.7
+# Default Python version is usually 3.6
 python: 3.5
 dist: xenial
 services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ dist: xenial
 services: docker
 osx_image: xcode9.3
 
-matrix:
+jobs:
   exclude:
       # Exclude the default Python 3.5 build
       - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ services: docker
 osx_image: xcode9.3
 
 jobs:
-  exclude:
-      # Exclude the default Python 3.5 build
-      - python: 3.5
   include:
     - name: "3.5 macOS"
       os: osx


### PR DESCRIPTION
Something changed at Travis CI which meant the matrix expanded to an empty list due to the combination of:

```yml
# Default Python version is usually 2.7
python: 3.5
```

And:

```yml
jobs:
  exclude:
      # Exclude the default Python 3.5 build
      - python: 3.5
```

See: https://github.com/python-pillow/pillow-wheels/pull/141#issuecomment-600495525

Removing the exclusion fixes it.

| [Last run](https://travis-ci.org/github/python-pillow/pillow-wheels/builds/656238590) | [This one](https://travis-ci.org/github/hugovk/pillow-wheels/builds/664122255) |
| - | - |
| ![image](https://user-images.githubusercontent.com/1324225/77007233-86f7e980-696c-11ea-9c62-eed7c4d04a3f.png) | ![image](https://user-images.githubusercontent.com/1324225/77007294-a262f480-696c-11ea-9116-e3495af3e810.png) |
