### PR TITLE
Add aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,28 @@ jobs:
         - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.6
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.7
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+
 
 before_install:
     - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,13 @@ jobs:
         - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 
+    - name: "3.5 Xenial aarch64"
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.5
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
     - name: "3.6 Xenial aarch64"
       arch: arm64
       env:
@@ -213,6 +220,15 @@ jobs:
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
 
+    - name: "3.5 Xenial aarch64 latest"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.5
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
     - name: "3.6 Xenial aarch64 latest"
       os: linux
       arch: arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,29 @@ jobs:
         - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 
+    - name: "3.6 Xenial aarch64"
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.6
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - name: "3.7 Xenial aarch64"
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.7
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - name: "3.8 Xenial aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+
     - name: "3.5 macOS latest"
       os: osx
       osx_image: xcode9.3
@@ -189,27 +212,34 @@ jobs:
         - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
-    - os: linux
+
+    - name: "3.6 Xenial aarch64 latest"
+      os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.6
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - MB_ML_VER=2014
-        - MB_PYTHON_VERSION=3.8
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
+        - LATEST="true"
+    - name: "3.7 Xenial aarch64 latest"
+      os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.7
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
+    - name: "3.8 Xenial aarch64 latest"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
 
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -25,6 +25,16 @@ function pre_build {
     if [ -n "$IS_OSX" ]; then
         # Update to latest zlib for OS X build
         build_new_zlib
+    elif [ $MB_ML_VER -eq 2014 ]; then
+        yum install -y cmake
+    
+        function get_cmake {
+            echo cmake
+        }
+
+        function build_xz {
+            yum install -y xz-devel
+        }
     fi
 
     if [ -n "$IS_OSX" ]; then


### PR DESCRIPTION
- update multibuild to latest devel commit
- add wheels for PyPy3 on linux64, aarch64 for python 3.6, 3.7, 3.8

When will Pillow drop support for python 3.5?