### PR TITLE
Compile libxcb on Linux

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -25,13 +25,17 @@ function pre_build {
     if [ -n "$IS_OSX" ]; then
         # Update to latest zlib for OS X build
         build_new_zlib
-        
+    fi
+
+    build_simple xcb-proto $LIBXCB_VERSION https://xcb.freedesktop.org/dist
+    if [ -n "$IS_OSX" ]; then
         build_simple xproto 7.0.31 https://www.x.org/pub/individual/proto
         build_simple libXau 1.0.9 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.4 https://xcb.freedesktop.org/dist
-        build_simple xcb-proto $LIBXCB_VERSION https://xcb.freedesktop.org/dist
-        build_simple libxcb $LIBXCB_VERSION https://xcb.freedesktop.org/dist
+    else
+        sed -i s/\${pc_sysrootdir\}// /usr/local/lib/pkgconfig/xcb-proto.pc
     fi
+    build_simple libxcb $LIBXCB_VERSION https://xcb.freedesktop.org/dist
     
     # Custom flags to include both multibuild and jpeg defaults
     ORIGINAL_CFLAGS=$CFLAGS
@@ -74,10 +78,7 @@ function run_tests_in_repo {
 
 EXP_CODECS="jpg jpg_2000 libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
-EXP_FEATURES="transp_webp webp_anim webp_mux"
-if [ -n "$IS_OSX" ]; then
-    EXP_FEATURES="$EXP_FEATURES xcb"
-fi
+EXP_FEATURES="transp_webp webp_anim webp_mux xcb"
 
 function run_tests {
     # Runs tests on installed distribution from an empty directory


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/4558

Trying to compile libxcb on Linux, I encountered
```
configure: error: Package requirements (xcb-proto >= 1.14) were not met:

Variable 'pc_sysrootdir' not defined in '/usr/local/lib/pkgconfig/xcb-proto.pc'

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables XCBPROTO_CFLAGS
and XCBPROTO_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

Printing `/usr/local/lib/pkgconfig/xcb-proto.pc`, I found
```
prefix=/usr/local
exec_prefix=${prefix}
datarootdir=${prefix}/share
datadir=${datarootdir}
libdir=${exec_prefix}/lib
xcbincludedir=${pc_sysrootdir}${datadir}/xcb
pythondir=${pc_sysrootdir}${prefix}/lib/python3.5/site-packages

Name: XCB Proto
Description: X protocol descriptions for XCB
Version: 1.14
```

Looking elsewhere in the Travis log, it can be seen that the full path to site-packages is `/usr/local/lib/python3.5/site-packages`. So `${pc_sysrootdir}` is empty for our setup, and I've just added a line to remove it with `sed`.

Why did this error occur on Linux and not on macOS? I would guess it is because they are running different versions of pkg-config. When I run `pkg-config --version` on TravisCI macOS, I get 0.29.2. On TravisCI Linux, I get 0.21.