### PR TITLE
Upload wheels to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ env:
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-cov"
       - MACOSX_DEPLOYMENT_TARGET=10.10
-      - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
-      # Following generated with
-      # travis encrypt -r python-pillow/pillow-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
-      - secure: "ky76goiK6n4k8V9/uG340GSFVwmjE7G76l9xbhhGZkcph4eTwN5VRM/tqyJvlNs/HZOhKSILfyGBeaG8qf7gHmwr0touPT+EjWn4TNV8iyVj75ZshgRE9DuaIAfdH89gW2m+BmvBDyzi0JE3KVCu55NcGm8h7Ecl6nmQ/c2iROY="
 
 language: python
 # Default Python version is usually 3.6
@@ -219,16 +215,20 @@ install:
     - if [[ -n "$LATEST" ]]; then BUILD_COMMIT=master; fi
     - clean_code $REPO_DIR $BUILD_COMMIT
     - build_wheel $REPO_DIR $PLAT
+    - ls -l "${TRAVIS_BUILD_DIR}/wheelhouse/"
 
 script:
     - install_run $PLAT
 
-after_success:
-    # Upload wheels to Rackspace container
-    - if [[ -z "$LATEST" ]]; then
-        pip install wheelhouse-uploader;
-        python -m wheelhouse_uploader upload --local-folder
-          ${TRAVIS_BUILD_DIR}/wheelhouse/
-          --no-update-index
-          wheels;
-      fi
+# Upload wheels to GitHub Releases
+deploy:
+  provider: releases
+  api_key:
+    secure: PTgVG7DrYa2FTSQOq0eDaHDZb1vy0vf6MulyuoXMg8rssPQgJ/mYxRpNDK4V0EKolpN7f8s/OGg+fpNNtp5pOCJGsx0Okcf+YB2ac+Xl7DQPBucbDKFXs1ndf/ny6umk0TXX8JTrDp/mJDJf401yx1+qsZ6X/PFvchXvXVrQ+SQ=
+  file_glob: true
+  file: "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/*.whl"
+  on:
+    condition: -z "$LATEST"
+    repo: python-pillow/pillow-wheels
+    tags: true
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,17 +106,20 @@ jobs:
       os: osx
       osx_image: xcode9.3
       language: generic
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.6
         - LATEST="true"
 
     - name: "3.6 Xenial latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.6
         - LATEST="true"
     - name: "3.6 Xenial 32-bit latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
@@ -126,6 +129,7 @@ jobs:
       os: osx
       osx_image: xcode9.3
       language: generic
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.7
         - LATEST="true"
@@ -133,28 +137,33 @@ jobs:
       os: osx
       osx_image: xcode9.3
       language: generic
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.8
         - LATEST="true"
 
     - name: "3.7 Xenial latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.7
         - LATEST="true"
     - name: "3.7 Xenial 32-bit latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - LATEST="true"
     - name: "3.8 Xenial latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.8
         - LATEST="true"
     - name: "3.8 Xenial 32-bit latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
@@ -164,12 +173,14 @@ jobs:
       os: osx
       osx_image: xcode9.3
       language: generic
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3
         - MB_PYTHON_OSX_VER=10.9
         - LATEST="true"
     - name: "3.6 Xenial 64-bit PyPy latest"
       os: linux
+      if: tag IS blank
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3
         - MB_ML_VER=2010
@@ -179,6 +190,7 @@ jobs:
     - name: "3.6 Xenial aarch64 latest"
       os: linux
       arch: arm64
+      if: tag IS blank
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
@@ -188,6 +200,7 @@ jobs:
     - name: "3.7 Xenial aarch64 latest"
       os: linux
       arch: arm64
+      if: tag IS blank
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
@@ -197,6 +210,7 @@ jobs:
     - name: "3.8 Xenial aarch64 latest"
       os: linux
       arch: arm64
+      if: tag IS blank
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,7 +229,7 @@ install:
     - if [[ -n "$LATEST" ]]; then BUILD_COMMIT=master; fi
     - clean_code $REPO_DIR $BUILD_COMMIT
     - build_wheel $REPO_DIR $PLAT
-    - ls -l "${TRAVIS_BUILD_DIR}/wheelhouse/"
+    - ls -l "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/"
 
 script:
     - install_run $PLAT


### PR DESCRIPTION
Fixes https://github.com/python-pillow/pillow-wheels/issues/146, using one of @mattip's suggestions.

Based on Cython's config:

* https://github.com/MacPython/cython-wheels/blob/b421040fd59ccd1cee9b2cb66b79a3d6bacde444/.travis.yml#L116-L125

Travis CI docs:

* https://docs.travis-ci.com/user/deployment/releases/

The wheels are only built for tags, and the workflow will change a bit so we'll need to update the main `RELEASING.md` checklist, this `README.md` and `update-pillow-tag.sh`.

When releasing, we add and push a tag. It builds as normal (and also skips the "latest" jobs, we don't need to build/deploy them). The wheels are uploaded to a [matching tag release here in this repo](https://github.com/python-pillow/pillow-wheels/releases). 

We can then download the wheels from the release, and can `twine upload` with the separately-built Windows wheels, and source ([this](https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8) looks handy for downloading).

(We *could* delete the release/files from here if we wanted to ensure PyPI is the place to go, not sure if that's necessary.)

Here's an example:

```diff
diff --git a/update-pillow-tag.sh b/update-pillow-tag.sh
index a48d6ca..c3000f1 100755
--- a/update-pillow-tag.sh
+++ b/update-pillow-tag.sh
@@ -15,4 +15,5 @@ git fetch --all
 git checkout $1
 cd ..
 git commit -m "Pillow -> $1" Pillow
-git push
+git tag "$1"
+git push --tags
```

Note we'd still need a normal `git push` (without `--tags`), but that will do a normal build of latest and non-latest (and no wheels), so that could come in the post-release thing, to avoid eating up CI time.

I'll annotate some lines too with some extra info.

