### PR TITLE
Updates for GitHub Releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,9 @@ earliest NumPy that Pillow is compatible with; see
 Wheels
 ------
 
-Wheels are uploaded to a
-`Rackspace container <https://a365fff413fe338398b6-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/>`_.
-Credentials for this container are encrypted to this specific repo in the
-``.travis.yml`` file, so the upload won't work from another repository.
+Wheels are uploaded to https://github.com/python-pillow/pillow-wheels/releases.
+Credentials are encrypted to this specific repo in the ``.travis.yml`` file,
+so the upload won't work from another repository.
 
 PyPI
 ~~~~

--- a/update-pillow-tag.sh
+++ b/update-pillow-tag.sh
@@ -15,4 +15,5 @@ git fetch --all
 git checkout $1
 cd ..
 git commit -m "Pillow -> $1" Pillow
-git push
+git tag $1
+git push origin $1


### PR DESCRIPTION
Sequel to #156

As suggested there, updates README now that the wheel destination has changed, and changes update-pillow-tag.sh to tag the update commit and push the tag.