### PR TITLE
Revert "Workaround problems with cmake and xz on manylinux2014"

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -25,16 +25,6 @@ function pre_build {
     if [ -n "$IS_OSX" ]; then
         # Update to latest zlib for OS X build
         build_new_zlib
-    elif [ $MB_ML_VER -eq 2014 ]; then
-        yum install -y cmake
-    
-        function get_cmake {
-            echo cmake
-        }
-
-        function build_xz {
-            yum install -y xz-devel
-        }
     fi
 
     if [ -n "$IS_OSX" ]; then


### PR DESCRIPTION
Reverts https://github.com/python-pillow/pillow-wheels/pull/147/commits/639793e150a6c5f1968f32271660a7c8326ccb20 and instead fixes the problem with https://github.com/matthew-brett/multibuild/pull/342. The multibuild PR changes from 'cmake28' to 'cmake' as we were doing, and instead of our install of xz-devel, skips building xz.