### PR TITLE
Use pillow-depends test images

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -97,6 +97,8 @@ function run_tests {
     fi
     pip install numpy
 
+    mv ../pillow-depends-master/test_images/* ../Pillow/Tests/images
+
     # Runs tests on installed distribution from an empty directory
     (cd ../Pillow && run_tests_in_repo)
     # Test against expected codecs, modules and features


### PR DESCRIPTION
While [pillow-depends](https://github.com/python-pillow/pillow-depends) is used by this repo for the dependency archives, the test images from depends are not used. This PR fixes that.

This is worthwhile just for the sake of more testing, but it also fixes a problem with master - because the depends test images are not present, https://github.com/python-pillow/Pillow/pull/4929 is now causing failures - https://travis-ci.org/github/python-pillow/pillow-wheels/jobs/729255498

Also could be a chance to test mergify on this PR?