### PR TITLE
Changed order of dependency

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -55,8 +55,8 @@ function pre_build {
     
     build_tiff
     build_libpng
-    build_openjpeg
     build_lcms2
+    build_openjpeg
 
     if [ -n "$IS_OSX" ]; then
         # Custom flags to allow building on OS X 10.10 and 10.11


### PR DESCRIPTION
Currently, `build_openjpeg` is performed before `build_lcms2`.

In [multibuild, `build_openjpeg` runs `build_lcms2` though](https://github.com/matthew-brett/multibuild/blob/bc8e01eac30648347b0dc687d6ab38158e016c57/library_builders.sh#L197-L202).

So if `build_lcms2` were to fail, then it would appear to be part of our `build_openjpeg` step, and our `build_lcms2` is unlikely to ever fail.

This PR changes the order of steps to better help potential debugging.