### PR TITLE
Move x86 jobs to GHA

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,33 @@
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  # these cause a conflict with built webp and libtiff
+  brew remove --ignore-dependencies webp zstd xz libtiff
+fi
+
+if [[ "$MB_PYTHON_VERSION" == "pypy3.6-7.3" ]]; then
+  if [[ "$TRAVIS_OS_NAME" != "macos-latest" ]]; then
+    MB_ML_VER="2010"
+    DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
+  else
+    MB_PYTHON_OSX_VER="10.9"
+  fi
+fi
+
+echo "::group::Install a virtualenv"
+  source multibuild/common_utils.sh
+  source multibuild/travis_steps.sh
+  # can't use default 7.3.1 on macOS due to https://foss.heptapod.net/pypy/pypy/-/issues/3229
+  LATEST_PP_7p3=7.3.2
+  pip install virtualenv
+  before_install
+echo "::endgroup::"
+
+echo "::group::Build wheel"
+  clean_code $REPO_DIR $BUILD_COMMIT
+  build_wheel $REPO_DIR $PLAT
+  ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
+echo "::endgroup::"
+
+echo "::group::Test wheel"
+  install_run $PLAT
+echo "::endgroup::"

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,5 +1,10 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  if [[ "$MB_PYTHON_VERSION" == "pypy3.6-7.3" ]]; then
+    # for https://foss.heptapod.net/pypy/pypy/-/issues/3229
+    # TODO remove when that is fixed
+    brew install tcl-tk
+  fi
   # these cause a conflict with built webp and libtiff
   brew remove --ignore-dependencies webp zstd xz libtiff
 fi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,12 +7,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ "ubuntu-16.04" ]
+        os: [ "ubuntu-16.04", "macos-latest" ]
         python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
         platform: [ "x86_64", "i686" ]
+        exclude:
+          - os: "macos-latest"
+            platform: "i686"
       fail-fast: false
 
-    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.platform }}
@@ -22,7 +24,7 @@ jobs:
       BUILD_COMMIT: HEAD
       BUILD_DEPENDS: ""
       TEST_DEPENDS: "pytest pytest-cov"
-      MACOSX_DEPLOYMENT_TARGET: 10.10
+      MACOSX_DEPLOYMENT_TARGET: "10.10"
       WHEEL_SDIR: wheelhouse
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
@@ -37,13 +39,14 @@ jobs:
         with:
           python-version: 3.8
 
-      # Run everything in a single step because GHA doesn't share envvars
       - name: Build Wheel
         run: |
           echo "::group::Install a virtualenv"
             if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
               # pretend we are on Travis CI
               TRAVIS_OS_NAME="osx"
+              # these cause a conflict with built webp and libtiff
+              brew remove --ignore-dependencies webp zstd xz libtiff
             fi
             if [[ "${{ matrix.python }}" == "pypy3.6-7.3" ]]; then
               # PyPy specific settings
@@ -56,6 +59,8 @@ jobs:
             fi
             source multibuild/common_utils.sh
             source multibuild/travis_steps.sh
+            # can't use default 7.3.1 on macOS due to https://foss.heptapod.net/pypy/pypy/-/issues/3229
+            LATEST_PP_7p3=7.3.2
             pip install virtualenv
             before_install
           echo "::endgroup::"
@@ -69,7 +74,14 @@ jobs:
             ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
           echo "::endgroup::"
 
-          install_run $PLAT
+          echo "::group::Test wheel"
+            install_run $PLAT
+          echo "::endgroup::"
+
+#     Uncomment to get SSH access for testing
+#      - name: Setup tmate session
+#        if: failure()
+#        uses: mxschmitt/action-tmate@v3
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 
 name: Wheels
 
-on: [push, pull_request, create]
+on: [push, pull_request]
 
 env:
   REPO_DIR: Pillow

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
+        python: [ "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
+        python: [ "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,7 +61,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Build wheel"
-            if [[ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ]]; then
+            if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "false" ]]; then
               BUILD_COMMIT=master
             fi
             clean_code $REPO_DIR $BUILD_COMMIT
@@ -75,3 +75,18 @@ jobs:
         with:
           name: wheels
           path: wheelhouse/*.whl
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Upload Release
+        uses: fnkr/github-action-ghr@v1.3
+        env:
+          GHR_PATH: .
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Build Wheel
         run: .github/workflows/build.sh
       - uses: actions/upload-artifact@v2
@@ -80,7 +80,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Build Wheel
         run: .github/workflows/build.sh
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,9 +3,19 @@ name: Wheels
 
 on: [push, pull_request, create]
 
+env:
+  REPO_DIR: Pillow
+  BUILD_DEPENDS: ""
+  TEST_DEPENDS: "pytest pytest-cov"
+  MACOSX_DEPLOYMENT_TARGET: "10.10"
+  WHEEL_SDIR: wheelhouse
+
 jobs:
   build:
+    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
         python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
@@ -13,85 +23,75 @@ jobs:
         exclude:
           - os: "macos-latest"
             platform: "i686"
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.platform }}
-
+        include:
+          - os: "macos-latest"
+            os-name: "osx"
+          - os: "ubuntu-16.04"
+            os-name: "xenial"
     env:
-      REPO_DIR: Pillow
       BUILD_COMMIT: HEAD
-      BUILD_DEPENDS: ""
-      TEST_DEPENDS: "pytest pytest-cov"
-      MACOSX_DEPLOYMENT_TARGET: "10.10"
-      WHEEL_SDIR: wheelhouse
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
-
+      TRAVIS_OS_NAME: ${{ matrix.os-name }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-
       - name: Build Wheel
-        run: |
-          echo "::group::Install a virtualenv"
-            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-              # pretend we are on Travis CI
-              TRAVIS_OS_NAME="osx"
-              # these cause a conflict with built webp and libtiff
-              brew remove --ignore-dependencies webp zstd xz libtiff
-            fi
-            if [[ "${{ matrix.python }}" == "pypy3.6-7.3" ]]; then
-              # PyPy specific settings
-              if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
-                MB_ML_VER="2010"
-                DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
-              else
-                MB_PYTHON_OSX_VER="10.9"
-              fi
-            fi
-            source multibuild/common_utils.sh
-            source multibuild/travis_steps.sh
-            # can't use default 7.3.1 on macOS due to https://foss.heptapod.net/pypy/pypy/-/issues/3229
-            LATEST_PP_7p3=7.3.2
-            pip install virtualenv
-            before_install
-          echo "::endgroup::"
-
-          echo "::group::Build wheel"
-            if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "false" ]]; then
-              BUILD_COMMIT=master
-            fi
-            clean_code $REPO_DIR $BUILD_COMMIT
-            build_wheel $REPO_DIR $PLAT
-            ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
-          echo "::endgroup::"
-
-          echo "::group::Test wheel"
-            install_run $PLAT
-          echo "::endgroup::"
-
-#     Uncomment to get SSH access for testing
-#      - name: Setup tmate session
-#        if: failure()
-#        uses: mxschmitt/action-tmate@v3
-
+        run: .github/workflows/build.sh
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
+          path: wheelhouse/*.whl
+      # Uncomment to get SSH access for testing
+      # - name: Setup tmate session
+      #   if: failure()
+      #   uses: mxschmitt/action-tmate@v3
+
+  build-latest:
+    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }} latest
+    runs-on: ${{ matrix.os }}
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-16.04", "macos-latest" ]
+        python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
+        platform: [ "x86_64", "i686" ]
+        exclude:
+          - os: "macos-latest"
+            platform: "i686"
+        include:
+          - os: "macos-latest"
+            os-name: "osx"
+          - os: "ubuntu-16.04"
+            os-name: "xenial"
+    env:
+      BUILD_COMMIT: master
+      PLAT: ${{ matrix.platform }}
+      MB_PYTHON_VERSION: ${{ matrix.python }}
+      TRAVIS_OS_NAME: ${{ matrix.os-name }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Build Wheel
+        run: .github/workflows/build.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels-latest
           path: wheelhouse/*.whl
 
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: "startsWith(github.ref, 'refs/tags/')"
     needs: build
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,77 @@
+
+name: Wheels
+
+on: [push, pull_request, create]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ "ubuntu-16.04" ]
+        python: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6-7.3" ]
+        platform: [ "x86_64", "i686" ]
+      fail-fast: false
+
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.platform }}
+
+    env:
+      REPO_DIR: Pillow
+      BUILD_COMMIT: HEAD
+      BUILD_DEPENDS: ""
+      TEST_DEPENDS: "pytest pytest-cov"
+      MACOSX_DEPLOYMENT_TARGET: 10.10
+      WHEEL_SDIR: wheelhouse
+      PLAT: ${{ matrix.platform }}
+      MB_PYTHON_VERSION: ${{ matrix.python }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      # Run everything in a single step because GHA doesn't share envvars
+      - name: Build Wheel
+        run: |
+          echo "::group::Install a virtualenv"
+            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+              # pretend we are on Travis CI
+              TRAVIS_OS_NAME="osx"
+            fi
+            if [[ "${{ matrix.python }}" == "pypy3.6-7.3" ]]; then
+              # PyPy specific settings
+              if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+                MB_ML_VER="2010"
+                DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
+              else
+                MB_PYTHON_OSX_VER="10.9"
+              fi
+            fi
+            source multibuild/common_utils.sh
+            source multibuild/travis_steps.sh
+            pip install virtualenv
+            before_install
+          echo "::endgroup::"
+
+          echo "::group::Build wheel"
+            if [[ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ]]; then
+              BUILD_COMMIT=master
+            fi
+            clean_code $REPO_DIR $BUILD_COMMIT
+            build_wheel $REPO_DIR $PLAT
+            ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
+          echo "::endgroup::"
+
+          install_run $PLAT
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse/*.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,38 +16,6 @@ services: docker
 
 jobs:
   include:
-    - name: "3.6 macOS"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.6
-    - name: "3.7 macOS"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.7
-    - name: "3.8 macOS"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.8
-    - name: "3.9 macOS"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.9
-    - name: "3.6 macOS PyPy"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=pypy3.6-7.3
-        - MB_PYTHON_OSX_VER=10.9
-
     - name: "3.6 Xenial aarch64"
       arch: arm64
       env:
@@ -78,48 +46,6 @@ jobs:
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.9
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-
-    - name: "3.6 macOS latest"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - LATEST="true"
-    - name: "3.7 macOS latest"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - LATEST="true"
-    - name: "3.8 macOS latest"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - LATEST="true"
-    - name: "3.9 macOS latest"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.9
-        - LATEST="true"
-    - name: "3.6 macOS PyPy latest"
-      os: osx
-      osx_image: xcode9.3
-      language: generic
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=pypy3.6-7.3
-        - MB_PYTHON_OSX_VER=10.9
-        - LATEST="true"
 
     - name: "3.6 Xenial aarch64 latest"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,6 @@ jobs:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-
-    - name: "3.6 Xenial"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-    - name: "3.6 Xenial 32-bit"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-
     - name: "3.7 macOS"
       os: osx
       osx_image: xcode9.3
@@ -51,35 +40,6 @@ jobs:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.9
-
-    - name: "3.7 Xenial"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-    - name: "3.7 Xenial 32-bit"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - PLAT=i686
-    - name: "3.8 Xenial"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.8
-    - name: "3.8 Xenial 32-bit"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - PLAT=i686
-    - name: "3.9 Xenial"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.9
-    - name: "3.9 Xenial 32-bit"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=3.9
-        - PLAT=i686
-
     - name: "3.6 macOS PyPy"
       os: osx
       osx_image: xcode9.3
@@ -87,12 +47,6 @@ jobs:
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3
         - MB_PYTHON_OSX_VER=10.9
-    - name: "3.6 Xenial 64-bit PyPy"
-      os: linux
-      env:
-        - MB_PYTHON_VERSION=pypy3.6-7.3
-        - MB_ML_VER=2010
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
 
     - name: "3.6 Xenial aarch64"
       arch: arm64
@@ -133,21 +87,6 @@ jobs:
       env:
         - MB_PYTHON_VERSION=3.6
         - LATEST="true"
-
-    - name: "3.6 Xenial latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - LATEST="true"
-    - name: "3.6 Xenial 32-bit latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-        - LATEST="true"
-
     - name: "3.7 macOS latest"
       os: osx
       osx_image: xcode9.3
@@ -172,47 +111,6 @@ jobs:
       env:
         - MB_PYTHON_VERSION=3.9
         - LATEST="true"
-
-    - name: "3.7 Xenial latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - LATEST="true"
-    - name: "3.7 Xenial 32-bit latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - PLAT=i686
-        - LATEST="true"
-    - name: "3.8 Xenial latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - LATEST="true"
-    - name: "3.8 Xenial 32-bit latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - PLAT=i686
-        - LATEST="true"
-    - name: "3.9 Xenial latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.9
-        - LATEST="true"
-    - name: "3.9 Xenial 32-bit latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=3.9
-        - PLAT=i686
-        - LATEST="true"
-
     - name: "3.6 macOS PyPy latest"
       os: osx
       osx_image: xcode9.3
@@ -221,14 +119,6 @@ jobs:
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3
         - MB_PYTHON_OSX_VER=10.9
-        - LATEST="true"
-    - name: "3.6 Xenial 64-bit PyPy latest"
-      os: linux
-      if: tag IS blank
-      env:
-        - MB_PYTHON_VERSION=pypy3.6-7.3
-        - MB_ML_VER=2010
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
 
     - name: "3.6 Xenial aarch64 latest"

--- a/config.sh
+++ b/config.sh
@@ -52,29 +52,19 @@ function pre_build {
     CFLAGS="$CFLAGS -g -O2"
     build_jpeg
     CFLAGS=$ORIGINAL_CFLAGS
-    
+
     build_tiff
     build_libpng
     build_lcms2
     build_openjpeg
 
-    if [ -n "$IS_OSX" ]; then
-        # Custom flags to allow building on OS X 10.10 and 10.11
-        build_giflib
-        
-        ORIGINAL_CPPFLAGS=$CPPFLAGS
-        CPPFLAGS=""
-    fi
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
     build_libwebp
     CFLAGS=$ORIGINAL_CFLAGS
-    if [ -n "$IS_OSX" ]; then
-        CPPFLAGS=$ORIGINAL_CPPFLAGS
-    fi
 
     if [ -n "$IS_OSX" ]; then
         # Custom freetype build
-        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
+        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no --with-brotli=no
     else
         build_freetype
     fi


### PR DESCRIPTION
This PR moves the x86 and x86_64 builds to GHA (needs to be manually enabled it seems). Unlike Travis CI, which has 5 parallel jobs, and the .org version has been slow lately, GHA gives 20 parallel jobs (max 5 macOS).

The GHA build of 20 Ubuntu and 10 macOS jobs takes ~30m, barely slower than the remaining 8 Arm64 builds on Travis.org (~26m) if queued immediately. Note that Arm64 seems to have a separate queue and is less affected by the slowdown.

Also adds a Linux 32-bit PyPy wheel, as I do not see a reason it was not added in #153. 

The macOS build uses the default XCode, currently 12.0.1. https://github.com/actions/virtual-environments/issues/1712 shows how to pin to a specific version if necessary. XCode 10.3 is the oldest version currently available: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode

More details are posted per-line below.