### PR TITLE
GHA: Fix macOS builds

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -5,8 +5,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     # TODO remove when that is fixed
     brew install tcl-tk
   fi
-  # these cause a conflict with built webp and libtiff
-  brew remove --ignore-dependencies webp zstd xz libtiff
+  # these cause a conflict with built webp and libtiff,
+  # curl from brew requires zstd, use system curl
+  brew remove --ignore-dependencies webp zstd xz libtiff curl
 fi
 
 if [[ "$MB_PYTHON_VERSION" == "pypy3.6-7.3" ]]; then


### PR DESCRIPTION
MacOS builds started failing because the Brew version of curl depends on zstd which is explicitly removed due to conflicts. Removing curl from Brew fixes this by using the system version of curl which does not need the brew zstd package.