### PR TITLE
Add PyPy3.7 wheels

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,6 +1,6 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  if [[ "$MB_PYTHON_VERSION" == "pypy3.6-7.3" ]]; then
+  if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
     # for https://foss.heptapod.net/pypy/pypy/-/issues/3229
     # TODO remove when that is fixed
     brew install tcl-tk
@@ -10,7 +10,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew remove --ignore-dependencies webp zstd xz libtiff curl
 fi
 
-if [[ "$MB_PYTHON_VERSION" == "pypy3.6-7.3" ]]; then
+if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   if [[ "$TRAVIS_OS_NAME" != "macos-latest" ]]; then
     MB_ML_VER="2010"
     DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3", "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3.3", "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3","pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3", "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3","pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3.3","pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"


### PR DESCRIPTION
Add pypy3.7 wheels. At some point perhaps pillow should consider dropping python3.6 across all implementations.