### PR TITLE
Build arm64 wheel

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -29,6 +29,8 @@ echo "::group::Build wheel"
   ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
 echo "::endgroup::"
 
-echo "::group::Test wheel"
-  install_run $PLAT
-echo "::endgroup::"
+if [[ $MACOSX_DEPLOYMENT_TARGET != "11.0" ]]; then
+  echo "::group::Test wheel"
+    install_run $PLAT
+  echo "::endgroup::"
+fi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,6 @@ env:
   REPO_DIR: Pillow
   BUILD_DEPENDS: ""
   TEST_DEPENDS: "pytest pytest-cov"
-  MACOSX_DEPLOYMENT_TARGET: "10.10"
   WHEEL_SDIR: wheelhouse
 
 jobs:
@@ -20,6 +19,7 @@ jobs:
         os: [ "ubuntu-16.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.3","pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
+        macos-target: [ "10.10" ]
         exclude:
           - os: "macos-latest"
             platform: "i686"
@@ -28,11 +28,17 @@ jobs:
             os-name: "osx"
           - os: "ubuntu-16.04"
             os-name: "xenial"
+          - os: "macos-11.0"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.9"
+            macos-target: "11.0"
     env:
       BUILD_COMMIT: HEAD
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
       TRAVIS_OS_NAME: ${{ matrix.os-name }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,6 +67,7 @@ jobs:
         os: [ "ubuntu-16.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.3", "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
+        macos-target: [ "10.10" ]
         exclude:
           - os: "macos-latest"
             platform: "i686"
@@ -69,11 +76,17 @@ jobs:
             os-name: "osx"
           - os: "ubuntu-16.04"
             os-name: "xenial"
+          - os: "macos-11.0"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.9"
+            macos-target: "11.0"
     env:
       BUILD_COMMIT: master
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
       TRAVIS_OS_NAME: ${{ matrix.os-name }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/5093

Updating multibuild to include https://github.com/matthew-brett/multibuild/pull/383 and https://github.com/matthew-brett/multibuild/pull/384, this PR adds a job to build an arm64 wheel on x86_64 (https://github.com/actions/runner/issues/805 would indicate that running arm64 directly is not an option).

Some notes
- It only builds Python 3.9, as ['3.9.1 is the first version of Python to support macOS 11 Big Sur'](https://www.python.org/downloads/release/python-391/)
- It skips openjpeg and xcb due to errors.
- It doesn't test the wheel, since the arm64 wheel can't be installed on x86_64. However, I have downloaded the wheel and tested it on my M1 machine, and it works.

Most importantly though, https://github.com/actions/virtual-environments/issues/2486 states that macOS 11 is currently limited to repositories that have used it before - so it will not work here. However, my fork of pillow-wheels has used it before, so it [passes](https://github.com/radarhere/pillow-wheels/runs/1765861094).

So while this PR will fail for now, if the code changes in this PR are approved, then a wheel generated by my fork could be uploaded to PyPI to fix https://github.com/python-pillow/Pillow/issues/5093 for the moment.
[Pillow-8.1.0-cp39-cp39-macosx_11_0_arm64.whl.zip](https://github.com/python-pillow/pillow-wheels/files/5870199/Pillow-8.1.0-cp39-cp39-macosx_11_0_arm64.whl.zip)