### PR TITLE
Updated PyPy 3.6 to 7.3.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3.3","pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3.3","pypy3.6-7.3.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         macos-target: [ "10.10" ]
         exclude:
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-16.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3.3", "pypy3.6-7.3", "3.6", "3.7", "3.8", "3.9" ]
+        python: [ "pypy3.7-7.3.3", "pypy3.6-7.3.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         macos-target: [ "10.10" ]
         exclude:


### PR DESCRIPTION
https://github.com/python-pillow/pillow-wheels/runs/1849032310?check_suite_focus=true#step:4:5748 shows
> [PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

This PR updates it - https://github.com/python-pillow/pillow-wheels/pull/191/checks?check_run_id=1853722612#step:4:4970
> [PyPy 7.3.3 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]