### PR TITLE
Removed existing libpng to fix arm64 OpenJPEG

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -56,11 +56,13 @@ function pre_build {
     CFLAGS=$ORIGINAL_CFLAGS
 
     build_tiff
+    if [ -n "$IS_MACOS" ]; then
+        # Remove existing libpng
+        rm /usr/local/lib/libpng*
+    fi
     build_libpng
     build_lcms2
-    if [[ $MACOSX_DEPLOYMENT_TARGET != "11.0" ]]; then
-	    build_openjpeg
-    fi
+    build_openjpeg
 
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
     build_libwebp
@@ -86,10 +88,7 @@ function run_tests_in_repo {
     pytest
 }
 
-EXP_CODECS="jpg"
-if [[ $MACOSX_DEPLOYMENT_TARGET != "11.0" ]]; then
-    EXP_CODECS="$EXP_CODECS jpg_2000"
-fi
+EXP_CODECS="jpg jpg_2000"
 EXP_CODECS="$EXP_CODECS libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
 EXP_FEATURES="transp_webp webp_anim webp_mux"


### PR DESCRIPTION
If I try to [build openjpeg](https://github.com/radarhere/pillow-wheels/commit/dc891e7560a5b8f0be6379cb99b3f51da485faeb) on arm64, it fails. Part of the error is "[ld: warning: ignoring file /usr/local/lib/libpng.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64](https://github.com/radarhere/pillow-wheels/runs/1857866652?check_suite_focus=true#step:4:3172)".

If I remove the existing libpng (on other macOS architectures as well, because why not, we're building our own anyway), then the job runs correctly - https://github.com/radarhere/pillow-wheels/runs/1859658262