### PR TITLE
Change workflow to use ubuntu-20.04

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-16.04", "macos-latest" ]
+        os: [ "ubuntu-20.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.3","pypy3.6-7.3.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         macos-target: [ "10.10" ]
@@ -26,7 +26,7 @@ jobs:
         include:
           - os: "macos-latest"
             os-name: "osx"
-          - os: "ubuntu-16.04"
+          - os: "ubuntu-20.04"
             os-name: "xenial"
 # Disable whilst not available
 #          - os: "macos-11.0"
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-16.04", "macos-latest" ]
+        os: [ "ubuntu-20.04", "macos-latest" ]
         python: [ "pypy3.7-7.3.3", "pypy3.6-7.3.3", "3.6", "3.7", "3.8", "3.9" ]
         platform: [ "x86_64", "i686" ]
         macos-target: [ "10.10" ]
@@ -75,7 +75,7 @@ jobs:
         include:
           - os: "macos-latest"
             os-name: "osx"
-          - os: "ubuntu-16.04"
+          - os: "ubuntu-20.04"
             os-name: "xenial"
           - os: "macos-11.0"
             os-name: "osx"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
           - os: "macos-latest"
             os-name: "osx"
           - os: "ubuntu-20.04"
-            os-name: "xenial"
+            os-name: "focal"
 # Disable whilst not available
 #          - os: "macos-11.0"
 #            os-name: "osx"
@@ -76,7 +76,7 @@ jobs:
           - os: "macos-latest"
             os-name: "osx"
           - os: "ubuntu-20.04"
-            os-name: "xenial"
+            os-name: "focal"
           - os: "macos-11.0"
             os-name: "osx"
             platform: "arm64"


### PR DESCRIPTION
> Ubuntu 16.04 is being deprecated. It is not recommended for new users.
> If any of your workflows use Ubuntu 16.04, migrate to Ubuntu 20.04 or 18.04.

https://github.com/actions/virtual-environments/issues/3287