### PR TITLE
Do not use libtiff 4.3.0 on macOS 11 builds

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -71,6 +71,9 @@ function pre_build {
     build_jpeg
     CFLAGS=$ORIGINAL_CFLAGS
 
+    if [[ -n "$IS_MACOS" && $MACOSX_DEPLOYMENT_TARGET == "11.0" ]]; then
+        TIFF_VERSION=4.2.0
+    fi
     build_tiff
     if [ -n "$IS_MACOS" ]; then
         # Remove existing libpng


### PR DESCRIPTION
I've noticed that in [my GitHub Actions job for macOS 11](https://github.com/radarhere/pillow-wheels/runs/2500211403), libtiff is failing to build.

One of the errors is
```
../version:1:1: error: expected unqualified-id
  4.3.0
```

This has been reported by another user at https://gitlab.com/libtiff/libtiff/-/issues/252, and was fixed in https://gitlab.com/libtiff/libtiff/-/merge_requests/243

Until the next version of libtiff is released though, this PR reverts to libtiff 4.2.0 for on macOS 11 builds.