### PR TITLE
Added Python 3.8 for arm64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,6 +34,11 @@ jobs:
 #            platform: "arm64"
 #            python: "3.9"
 #            macos-target: "11.0"
+#          - os: "macos-11.0"
+#            os-name: "osx"
+#            platform: "arm64"
+#            python: "3.8"
+#            macos-target: "11.0"
     env:
       BUILD_COMMIT: HEAD
       PLAT: ${{ matrix.platform }}
@@ -81,6 +86,11 @@ jobs:
             os-name: "osx"
             platform: "arm64"
             python: "3.9"
+            macos-target: "11.0"
+          - os: "macos-11.0"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.8"
             macos-target: "11.0"
     env:
       BUILD_COMMIT: master

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,16 +82,17 @@ jobs:
             os-name: "osx"
           - os: "ubuntu-20.04"
             os-name: "focal"
-          - os: "macos-11.0"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.9"
-            macos-target: "11.0"
-          - os: "macos-11.0"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.8"
-            macos-target: "11.0"
+# Disable whilst not available
+#          - os: "macos-11.0"
+#            os-name: "osx"
+#            platform: "arm64"
+#            python: "3.9"
+#            macos-target: "11.0"
+#          - os: "macos-11.0"
+#            os-name: "osx"
+#            platform: "arm64"
+#            python: "3.8"
+#            macos-target: "11.0"
     env:
       BUILD_COMMIT: master
       PLAT: ${{ matrix.platform }}

--- a/config.sh
+++ b/config.sh
@@ -28,7 +28,14 @@ function untar {
         gz|tgz) tar -zxf $in_fname ;;
         bz2) tar -jxf $in_fname ;;
         zip) unzip -qq $in_fname ;;
-        xz) unxz -c $in_fname | tar -xf - ;;
+        xz) if [ -n "$IS_MACOS" ]; then
+              tar -xf $in_fname
+            else
+              if [[ ! $(type -P "unxz") ]]; then
+                echo xz must be installed to uncompress file; exit 1
+              fi
+              unxz -c $in_fname | tar -xf -
+            fi ;;
         *) echo Did not recognize extension $extension; exit 1 ;;
     esac
 }


### PR DESCRIPTION
Python 3.8.10 now supports M1 - https://www.python.org/downloads/release/python-3810/
> But there's a bunch of important updates here regardless, the biggest being Big Sur and Apple Silicon build support.

So this PR adds a Python 3.8 M1 build. It also updates multibuild to include https://github.com/matthew-brett/multibuild/pull/407, so that 3.8 is 3.8.10.

While I'm here, I'm including part of https://github.com/matthew-brett/multibuild/pull/406. It fixes multibuild's `untar` function on M1 (see https://github.com/radarhere/pillow-wheels/runs/2619227992 for a failure without this, and https://github.com/radarhere/pillow-wheels/runs/2620094931 for a pass with it).