### PR TITLE
Updated Travis CI to Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 language: python
 # Default Python version is usually 3.6
 python: 3.9
-dist: xenial
+dist: focal
 services: docker
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-cov"
-      - MACOSX_DEPLOYMENT_TARGET=10.10
 
 language: python
 # Default Python version is usually 3.6


### PR DESCRIPTION
Also removes unused `MACOSX_DEPLOYMENT_TARGET` variable.