### PR TITLE
Build zlib on Linux as well

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -45,10 +45,8 @@ function pre_build {
     # Runs in the root directory of this repository.
     curl -fsSL -o pillow-depends-master.zip https://github.com/python-pillow/pillow-depends/archive/master.zip
     untar pillow-depends-master.zip
-    if [ -n "$IS_MACOS" ]; then
-        # Update to latest zlib for macOS build
-        build_new_zlib
-    fi
+
+    build_new_zlib
 
     if [ -n "$IS_MACOS" ]; then
         ORIGINAL_BUILD_PREFIX=$BUILD_PREFIX


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/issues/5544 points out that our Linux wheels contain zlib 1.2.3.

Despite

https://github.com/python-pillow/pillow-wheels/blob/fd81da7e32593d38b69930b72a74178a4b1e74f9/config.sh#L10

We're only currently upgrading it on macOS.

https://github.com/python-pillow/pillow-wheels/blob/fd81da7e32593d38b69930b72a74178a4b1e74f9/config.sh#L48-L51

So this PR runs `build_new_zlib` on Linux as well.

There is a [warning attached to this in multibuild.](https://github.com/matthew-brett/multibuild/blob/7642786fb6085c459dc1fdd83a9ab41195f3f1e0/library_builders.sh#L146-L150), but that would only be a warning for our build process, not for the end user.
> Careful, this one may cause yum to segfault

See https://github.com/radarhere/pillow-wheels/commit/874bb0a48f3d2c14da6f85eed3b0a8503ab5658b and https://github.com/radarhere/pillow-wheels/actions/runs/942830985#artifacts for an example of what this change outputs.