### PR TITLE
OSX: brew remove php

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,7 +1,8 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  # these cause a conflict with built webp and libtiff,
+  # webp, zstd, xz, libtiff cause a conflict with building webp and libtiff
   # curl from brew requires zstd, use system curl
+  # if php is installed, brew tries to reinstall these after installing openblas
   brew remove --ignore-dependencies webp zstd xz libtiff curl php
 fi
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,7 +2,7 @@
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # these cause a conflict with built webp and libtiff,
   # curl from brew requires zstd, use system curl
-  brew remove --ignore-dependencies webp zstd xz libtiff curl
+  brew remove --ignore-dependencies webp zstd xz libtiff curl php
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then


### PR DESCRIPTION
Fixes the recent build failure, noted in https://github.com/python-pillow/pillow-wheels/pull/204#issuecomment-862631104

When `brew install openblas` is run before running tests, [brew reinstalls zstd](https://github.com/nulano/pillow-wheels/runs/2842802623?check_suite_focus=true#step:4:6661) (which was removed in `build.sh` due to compile errors IIRC). It then notices that the php package depends on zstd and [attempts to reinstall its dependencies](https://github.com/nulano/pillow-wheels/runs/2842802623?check_suite_focus=true#step:4:6682) (which were removed in `build.sh` due to conflicts). These [fail to install from brew](https://github.com/nulano/pillow-wheels/runs/2842802623?check_suite_focus=true#step:4:6708) because they were installed from source during Pillow compilation.

Removing php prevents brew from attempting to repair/reinstall these packages.