### PR TITLE
Added build_xz

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -24,6 +24,7 @@ function pre_build {
     curl -fsSL -o pillow-depends-master.zip https://github.com/python-pillow/pillow-depends/archive/master.zip
     untar pillow-depends-master.zip
 
+    build_xz
     build_new_zlib
 
     if [ -n "$IS_MACOS" ]; then


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/5604

When #208 updated multibuild, part of the update switched to using [`brew install xz` on macOS instead of `build_xz`](https://github.com/matthew-brett/multibuild/pull/406/commits/d451c58f89b270d3c67130cae27939305468e637).

Two reasons why we should `build_xz` to compile it from source instead -
1. By compiling it from source, we respect our deployment target, whereas [Homebrew just targets the current OS version.](https://github.com/Homebrew/legacy-homebrew/issues/48437#issuecomment-174522431). This led to https://github.com/python-pillow/Pillow/issues/5604
2. We previously uninstalled Homebrew xz since it can ["cause a conflict with building webp and libtiff"](https://github.com/python-pillow/pillow-wheels/blob/90fdd92a9e26da0acbe65db43b8ba56ec2f5d9ff/.github/workflows/build.sh#L3-L6)