### PR TITLE
Travis CI: Build on Python 3.10-dev 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,14 @@ jobs:
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.9
         - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+    - name: "3.10 Focal aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.10
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
 
 before_install:
     - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,36 +15,36 @@ services: docker
 
 jobs:
   include:
-    - name: "3.6 Xenial aarch64"
+    - name: "3.6 Focal aarch64"
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.6
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - name: "3.7 Xenial aarch64"
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+    - name: "3.7 Focal aarch64"
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.7
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - name: "3.8 Xenial aarch64"
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+    - name: "3.8 Focal aarch64"
       os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.8
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - name: "3.9 Xenial aarch64"
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+    - name: "3.9 Focal aarch64"
       os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.9
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
 
 before_install:
     - source multibuild/common_utils.sh


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/5569.

Also:

* Replace EOL Xenial with Focal, because the Xenial images contain an older version of pip which doesn't support Python 3.10
* Add some simple YAML/merge conflict linting (it caught some YAML indent mistakes I made from commenting/uncommenting)
