### PR TITLE
Test 64-bit Linux PyPy on focal

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -8,7 +8,11 @@ fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   if [[ "$TRAVIS_OS_NAME" != "macos-latest" ]]; then
-    DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
+    if [[ "$PLAT" == "i686" ]]; then
+      DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
+    else
+      DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
+    fi
   else
     MB_PYTHON_OSX_VER="10.9"
   fi

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -7,14 +7,11 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
-  if [[ "$TRAVIS_OS_NAME" != "macos-latest" ]]; then
-    if [[ "$PLAT" == "i686" ]]; then
-      DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
-    else
-      DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
-    fi
+  MB_PYTHON_OSX_VER="10.9"
+  if [[ "$PLAT" == "i686" ]]; then
+    DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
   else
-    MB_PYTHON_OSX_VER="10.9"
+    DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
   fi
 fi
 


### PR DESCRIPTION
Suggested in https://github.com/python-pillow/pillow-wheels/pull/217#issuecomment-906182740, this PR updates the docker test image for Linux PyPy to focal... but only for 64-bit, since there aren't 32-bit focal images available at https://hub.docker.com/u/multibuild

https://github.com/multi-build/docker-images/pull/14 and https://github.com/multi-build/docker-images/pull/15 fixed the problem that I [originally](https://github.com/python-pillow/pillow-wheels/pull/217#issuecomment-906379167) had in making this update.

This also has a commit allowing `MB_PYTHON_OSX_VER` to be set on Linux and `DOCKER_TEST_IMAGE` to be set on macOS - since it simplifies the code and has no effect.