### PR TITLE
Update GitHub Releases API token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
 deploy:
   provider: releases
   api_key:
-    secure: PTgVG7DrYa2FTSQOq0eDaHDZb1vy0vf6MulyuoXMg8rssPQgJ/mYxRpNDK4V0EKolpN7f8s/OGg+fpNNtp5pOCJGsx0Okcf+YB2ac+Xl7DQPBucbDKFXs1ndf/ny6umk0TXX8JTrDp/mJDJf401yx1+qsZ6X/PFvchXvXVrQ+SQ=
+    secure: $GITHUB_RELEASE_TOKEN
   file_glob: true
   file: "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/*.whl"
   on:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/5711 / https://github.com/python-pillow/Pillow/issues/5711#issuecomment-919069172.

Re: https://twitter.com/peter_szilagyi/status/1437646118700175360.

The `travis` CLI tool is being difficult:

```console
$ travis login --auto --com
Successfully logged in as hugovk!
$ travis encrypt --com
repository not known to https://api.travis-ci.com/: python-pillow/pillow-wheels/
```


So I've put the regenerated GitHub personal access token as a private environment variable at:

![image](https://user-images.githubusercontent.com/1324225/133259460-61482fae-01db-4542-91d6-905cc8cbc62d.png)

https://app.travis-ci.com/github/python-pillow/pillow-wheels/settings

This also makes it easier and quicker to delete/rotate the key in future.