### PR TITLE
Update GH Releases key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,7 @@ script:
 # Upload wheels to GitHub Releases
 deploy:
   provider: releases
-  api_key:
-    secure: $GITHUB_RELEASE_TOKEN
+  api_key: $GITHUB_RELEASE_TOKEN
   file_glob: true
   file: "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/*.whl"
   on:


### PR DESCRIPTION
The build from https://github.com/python-pillow/pillow-wheels/pull/221 errored with "Bad credentials":
```
/home/travis/.rvm/gems/ruby-2.7.0/gems/octokit-4.6.2/lib/octokit/response/raise_error.rb:16:in `on_complete': GET https://api.github.com/user: 401 - Bad credentials // See: https://docs.github.com/rest (Octokit::Unauthorized)
```
https://app.travis-ci.com/github/python-pillow/pillow-wheels/jobs/537440637#L7117

Looks like `secure:` is only needed for vars which are encrypted and pasted into the `.travis.yml`, for comparison:

* https://github.com/hellosign/hellosign-embedded/blob/0364b978c2e8357b2d4f5a0ba4d4c56b654455d4/.travis.yml#L80
* https://travis-ci.org/github/hellosign/hellosign-embedded/builds/771573691