### PR TITLE
Fix failing Linux jobs

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -25,6 +25,9 @@ function pre_build {
     untar pillow-depends-master.zip
 
     build_xz
+    if [ -z "$IS_MACOS" ]; then
+        yum remove -y zlib-devel
+    fi
     build_new_zlib
 
     if [ -n "$IS_MACOS" ]; then

--- a/config.sh
+++ b/config.sh
@@ -98,6 +98,10 @@ function pre_build {
 }
 
 function pip_wheel_cmd {
+    if [ -z "$IS_MACOS" ]; then
+        pipx install --force "auditwheel<5"
+    fi
+
     local abs_wheelhouse=$1
     if [ -z "$IS_MACOS" ]; then
         CFLAGS="$CFLAGS --std=c99"  # for Raqm


### PR DESCRIPTION
Linux jobs in master are currently failing - https://github.com/python-pillow/pillow-wheels/runs/3674659897?check_suite_focus=true#step:4:3512
> /opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: ./.libs/libpng16.so: undefined reference to `inflateValidate'

This is [due to an older version of zlib being used](https://sourceforge.net/p/libpng/bugs/267/), so I put together a commit to remove the existing version, so that our built version will be used instead.

However, that lead to a different error - https://github.com/radarhere/pillow-wheels/runs/3686958074?check_suite_focus=true#step:4:6598
> auditwheel: error: cannot repair "/io/wheelhouse/Pillow-8.3.2-cp310-cp310-linux_x86_64.whl" to "manylinux2014_x86_64" ABI because of the presence of too-recent versioned symbols. You'll need to compile the wheel on an older toolchain.

I suspect this is all related to the recent release of [auditwheel 5.0](https://github.com/pypa/auditwheel/releases/tag/5.0.0). Adding another commit to downgrade auditwheel to less than 5, master begins passing again.