### PR TITLE
Changed multibuild remote from matthew-brett to multi-build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/python-Pillow/Pillow.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/matthew-brett/multibuild.git
+	url = git://github.com/multi-build/multibuild.git


### PR DESCRIPTION
Development has moved from https://github.com/matthew-brett/multibuild/ to https://github.com/multi-build/multibuild