### PR TITLE
Update GitHub git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Pillow"]
 	path = Pillow
-	url = git://github.com/python-Pillow/Pillow.git
+	url = https://github.com/python-Pillow/Pillow.git
 [submodule "multibuild"]
 	path = multibuild
-	url = git://github.com/multi-build/multibuild.git
+	url = https://github.com/multi-build/multibuild.git


### PR DESCRIPTION
GitHub will be removing support for `git://`

* https://github.blog/2021-09-01-improving-git-protocol-security-github/