### PR TITLE
Fix failing main build

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -133,9 +133,11 @@ function run_tests {
         brew install openblas
         echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
     fi
-    if [[ "$MB_PYTHON_VERSION" == pypy3.7-* ]]; then
+    if [[ "$MB_PYTHON_VERSION" == pypy3.7-* ]] && [[ $(uname -m) == "i686" ]]; then
         python3 -m pip install numpy==1.20.3
-    elif [[ "$MB_PYTHON_VERSION" != 3.10 ]] || [[ "$PLAT" != "x86_64" ]]; then
+    elif [[ "$MB_PYTHON_VERSION" == 3.10 ]] && [[ $(uname -m) == "i686" ]]; then
+        python3 -m pip install numpy==1.21.4
+    else
         python3 -m pip install numpy
     fi
 

--- a/config.sh
+++ b/config.sh
@@ -57,7 +57,7 @@ function pre_build {
     build_jpeg
     CFLAGS=$ORIGINAL_CFLAGS
 
-    if [[ -n "$IS_MACOS" && $MACOSX_DEPLOYMENT_TARGET == "11.0" ]]; then
+    if [[ -n "$IS_MACOS" ]]; then
         TIFF_VERSION=4.2.0
     fi
     build_tiff


### PR DESCRIPTION
If I checkout main as main2, just to rerun it, it fails - https://github.com/python-pillow/pillow-wheels/actions/runs/1633179830

This PR
- expands #197 to cover more macOS jobs, since it seems GHA has upgraded others to macOS 11
- changes the NumPy versions. The latest version is now used for all jobs, except for 32-bit PyPy where 1.20.3 is used, and 32-bit Python 3.10, where 1.21.4 is used (presumably this is a result of the fact that [numpy doesn't seen a future for 32-bit wheels](https://github.com/python-pillow/pillow-wheels/pull/225#issuecomment-939269116)).