### PR TITLE
Limit numpy on 32-bit to 1.21.5 for Python 3.8 and 3.9

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -147,6 +147,8 @@ function run_tests {
         python3 -m pip install numpy==1.20.3
     elif [[ "$MB_PYTHON_VERSION" == 3.10 ]] && [[ $(uname -m) == "i686" ]]; then
         python3 -m pip install numpy==1.21.4
+    elif [[ "$MB_PYTHON_VERSION" == 3.8 || "$MB_PYTHON_VERSION" == 3.9 ]] && [[ $(uname -m) == "i686" ]]; then
+        python3 -m pip install numpy==1.21.5
     else
         python3 -m pip install numpy
     fi


### PR DESCRIPTION
If I checkout main as main2, just to rerun it, it fails - https://github.com/python-pillow/pillow-wheels/actions/runs/1645221714

This would be because numpy 1.22.0 was released yesterday.