### PR TITLE
Add GHA CI to Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - label=automerge
       - status-success=Lint
       - status-success=Travis CI - Pull Request
-      - status-success=Wheels
+      - status-success=Wheels Successful
     actions:
       merge:
         method: merge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,9 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - label=automerge
+      - status-success=Lint
       - status-success=Travis CI - Pull Request
+      - status-success=Wheels
     actions:
       merge:
         method: merge

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    name: Lint
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -135,3 +135,11 @@ jobs:
         env:
           GHR_PATH: .
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  success:
+    needs: [build, build-latest]
+    runs-on: ubuntu-latest
+    name: Wheels Successful
+    steps:
+      - name: Success
+        run: echo Wheels Successful

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 
 name: Wheels
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   REPO_DIR: Pillow


### PR DESCRIPTION
We've not updated Mergify in this repo after we added GitHub Actions, I was a little surprised when I added `automerge` to https://github.com/python-pillow/pillow-wheels/pull/240 and it merged after Travis CI passed but GHA was still running :)