### PR TITLE
Travis CI: Use Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 language: python
 # Default Python version is usually 3.6
-python: 3.9
+python: "3.10"
 dist: focal
 services: docker
 


### PR DESCRIPTION
Last bit for https://github.com/python-pillow/Pillow/issues/5569.

Three months after release, Travis CI finally has `3.10` available.

* https://travis-ci.community/t/add-python-3-10/12220/14?u=hugovk