### PR TITLE
brew remove libxcb libxdmcp

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,9 +1,9 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  # webp, zstd, xz, libtiff, libxcb, libxdmcp cause a conflict with building webp, libtiff, libxcb
+  # webp, zstd, xz, libtiff, libxcb cause a conflict with building webp, libtiff, libxcb
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,9 +1,9 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  # webp, zstd, xz, libtiff cause a conflict with building webp and libtiff
+  # webp, zstd, xz, libtiff, libxcb, libxdmcp cause a conflict with building webp, libtiff, libxcb
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
-  brew remove --ignore-dependencies webp zstd xz libtiff curl php
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then


### PR DESCRIPTION
Potential fix for https://github.com/python-pillow/Pillow/issues/6015

The generated wheel no longer contains dylibs with different permissions, but I don't have a mac system to test myself.
![image](https://user-images.githubusercontent.com/3819630/152390825-fb9508dc-b61a-425f-992c-faf2e2408c1e.png)
