### PR TITLE
Removed NumPy instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,16 +35,6 @@ See the ``pre_build`` in ``config.sh`` and the ``fetch_unpack`` routine in
 ``multibuild/library_builders.sh`` for the filename to give to the downloaded
 archive.
 
-Dependencies
-------------
-
-NumPy
-~~~~~
-
-Check minimum NumPy versions to build against in ``.travis.yml`` file. Build against the
-earliest NumPy that Pillow is compatible with; see
-`forward, backward NumPy compatibility <https://stackoverflow.com/questions/17709641/valueerror-numpy-dtype-has-the-wrong-size-try-recompiling/18369312#18369312>`_
-
 Wheels
 ------
 


### PR DESCRIPTION
The README contains some instructions about NumPy.

> Check minimum NumPy versions to build against in .travis.yml file. Build against the earliest NumPy that Pillow is compatible with; see [forward, backward NumPy compatibility](https://stackoverflow.com/questions/17709641/valueerror-numpy-dtype-has-the-wrong-size-try-recompiling/18369312#18369312)

This was originally added in https://github.com/python-pillow/pillow-wheels/commit/2efbaa41d5507f0c9ad554

I don't think these special instructions are necessary, as we don't interact with NumPy at an ABI level. There are no special instructions for olefile, another optional Python dependency of Pillow. Also, .travis.yml doesn't currently mention NumPy at all.

So this PR suggests that we remove those instructions.