### PR TITLE
Added pytest-timeout

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,7 +6,7 @@ on: [push, pull_request, workflow_dispatch]
 env:
   REPO_DIR: Pillow
   BUILD_DEPENDS: ""
-  TEST_DEPENDS: "pytest pytest-cov"
+  TEST_DEPENDS: "pytest pytest-cov pytest-timeout"
   WHEEL_SDIR: wheelhouse
 
 jobs:


### PR DESCRIPTION
Resolves warnings like https://github.com/python-pillow/pillow-wheels/runs/5228681289#step:4:6885
>   Tests/test_file_eps.py:292
>    /io/Pillow/Tests/test_file_eps.py:292: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
>      @pytest.mark.timeout(timeout=5)