### PR TITLE
Remove duplication with a reusable workflow

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -1,0 +1,75 @@
+name: Build wheels
+
+on:
+  workflow_call:
+    inputs:
+      build-commit:
+        required: true
+        type: string
+      artifacts-name:
+        required: true
+        type: string
+
+env:
+  REPO_DIR: Pillow
+  BUILD_DEPENDS: ""
+  TEST_DEPENDS: "pytest pytest-cov pytest-timeout"
+  WHEEL_SDIR: wheelhouse
+
+jobs:
+  build:
+    name: ${{ matrix.os-name }} ${{ matrix.python }} ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "macos-latest", "ubuntu-20.04" ]
+        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
+        platform: [ "x86_64", "i686" ]
+        macos-target: [ "10.10" ]
+        exclude:
+          - os: "macos-latest"
+            platform: "i686"
+        include:
+          - os: "macos-latest"
+            os-name: "osx"
+          - os: "ubuntu-20.04"
+            os-name: "focal"
+          - os: "macos-11"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.10"
+            macos-target: "11.0"
+          - os: "macos-11"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.9"
+            macos-target: "11.0"
+          - os: "macos-11"
+            os-name: "osx"
+            platform: "arm64"
+            python: "3.8"
+            macos-target: "11.0"
+    env:
+      BUILD_COMMIT: ${{ inputs.build-commit }}
+      PLAT: ${{ matrix.platform }}
+      MB_PYTHON_VERSION: ${{ matrix.python }}
+      TRAVIS_OS_NAME: ${{ matrix.os-name }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Build Wheel
+        run: .github/workflows/build.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifacts-name }}
+          path: wheelhouse/*.whl
+      # Uncomment to get SSH access for testing
+      # - name: Setup tmate session
+      #   if: failure()
+      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,125 +1,20 @@
-
 name: Wheels
 
 on: [push, pull_request, workflow_dispatch]
 
-env:
-  REPO_DIR: Pillow
-  BUILD_DEPENDS: ""
-  TEST_DEPENDS: "pytest pytest-cov pytest-timeout"
-  WHEEL_SDIR: wheelhouse
-
 jobs:
   build:
-    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ "ubuntu-20.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "x86_64", "i686" ]
-        macos-target: [ "10.10" ]
-        exclude:
-          - os: "macos-latest"
-            platform: "i686"
-        include:
-          - os: "macos-latest"
-            os-name: "osx"
-          - os: "ubuntu-20.04"
-            os-name: "focal"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.10"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.9"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.8"
-            macos-target: "11.0"
-    env:
-      BUILD_COMMIT: HEAD
-      PLAT: ${{ matrix.platform }}
-      MB_PYTHON_VERSION: ${{ matrix.python }}
-      TRAVIS_OS_NAME: ${{ matrix.os-name }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Build Wheel
-        run: .github/workflows/build.sh
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: wheelhouse/*.whl
-      # Uncomment to get SSH access for testing
-      # - name: Setup tmate session
-      #   if: failure()
-      #   uses: mxschmitt/action-tmate@v3
+    uses: ./.github/workflows/wheels-build.yml
+    with:
+      build-commit: "HEAD"
+      artifacts-name: "wheels"
 
   build-latest:
-    name: ${{ matrix.python }} ${{ matrix.os-name }} ${{ matrix.platform }} latest
-    runs-on: ${{ matrix.os }}
     if: "!startsWith(github.ref, 'refs/tags/')"
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ "ubuntu-20.04", "macos-latest" ]
-        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "x86_64", "i686" ]
-        macos-target: [ "10.10" ]
-        exclude:
-          - os: "macos-latest"
-            platform: "i686"
-        include:
-          - os: "macos-latest"
-            os-name: "osx"
-          - os: "ubuntu-20.04"
-            os-name: "focal"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.10"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.9"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.8"
-            macos-target: "11.0"
-    env:
-      BUILD_COMMIT: main
-      PLAT: ${{ matrix.platform }}
-      MB_PYTHON_VERSION: ${{ matrix.python }}
-      TRAVIS_OS_NAME: ${{ matrix.os-name }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Build Wheel
-        run: .github/workflows/build.sh
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels-latest
-          path: wheelhouse/*.whl
+    uses: ./.github/workflows/wheels-build.yml
+    with:
+      build-commit: "main"
+      artifacts-name: "wheels-latest"
 
   release:
     name: Create Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.swp
 *~
+.idea
 build
-working
 downloads
+working


### PR DESCRIPTION
We can refactor `build` and `build-latest` into a single _resuable workflow_ and pass inputs for their differences.

Docs:
* https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/
* https://docs.github.com/en/actions/using-workflows/reusing-workflows

Not terribly happy with the `wheels.yml` + `wheels-reusable.yml` names, suggestions welcome!

---

Also put slower macOS first in the matrix, might speed things up a bit:

```diff
-        os: [ "ubuntu-20.04", "macos-latest" ]
+        os: [ "macos-latest", "ubuntu-20.04" ]
```

And while GHA gives 20 concurrent jobs, I just spotted the limit for macOS is 5: 

https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits

So another reason to get those queued up sooner.