### PR TITLE
Refactored arm64 jobs to exclude rather than include

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,6 +4,12 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
   brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php
+
+  if [[ "$PLAT" == "arm64" ]]; then
+    MACOSX_DEPLOYMENT_TARGET="11.0"
+  else
+    MACOSX_DEPLOYMENT_TARGET="10.10"
+  fi
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -25,37 +25,31 @@ jobs:
       matrix:
         os: [ "macos-latest", "ubuntu-20.04" ]
         python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "x86_64", "i686" ]
-        macos-target: [ "10.10" ]
+        platform: [ "arm64", "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"
             platform: "i686"
+          - os: "macos-latest"
+            platform: "arm64"
+            python: "3.7"
+          - os: "macos-latest"
+            platform: "arm64"
+            python: "pypy3.7-7.3.8"
+          - os: "macos-latest"
+            platform: "arm64"
+            python: "pypy3.8-7.3.8"
+          - os: "ubuntu-20.04"
+            platform: "arm64"
         include:
           - os: "macos-latest"
             os-name: "osx"
           - os: "ubuntu-20.04"
             os-name: "focal"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.10"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.9"
-            macos-target: "11.0"
-          - os: "macos-11"
-            os-name: "osx"
-            platform: "arm64"
-            python: "3.8"
-            macos-target: "11.0"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
       TRAVIS_OS_NAME: ${{ matrix.os-name }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-target }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
For macOS arm64, rather than adding on Python 3.8-3.10, this PR removes Python 3.7 and PyPy.

I think this better communicates what is happening, but it's not exactly shorter, so feel free to disregard this if you want.