### PR TITLE
Downgraded PyPy to 7.3.5, removed PyPy3.8

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-latest", "ubuntu-20.04" ]
-        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
+        python: [ "pypy3.7-7.3.5", "3.7", "3.8", "3.9", "3.10" ]
         platform: [ "arm64", "x86_64", "i686" ]
         exclude:
           - os: "macos-latest"
@@ -34,10 +34,7 @@ jobs:
             python: "3.7"
           - os: "macos-latest"
             platform: "arm64"
-            python: "pypy3.7-7.3.8"
-          - os: "macos-latest"
-            platform: "arm64"
-            python: "pypy3.8-7.3.8"
+            python: "pypy3.7-7.3.5"
           - os: "ubuntu-20.04"
             platform: "arm64"
         include:


### PR DESCRIPTION
We can hold off merging this for now, but in case PyPy doesn't release 7.3.9 before April 1 - this downgrades to PyPy to 7.3.5 (the last valid release according to https://github.com/python-pillow/pillow-wheels/pull/256#issuecomment-1073136732), and also removes PyPy3.8, since that [only came out of beta in 7.3.8.](https://www.pypy.org/posts/2022/02/pypy-v738-release.html)