### PR TITLE
Added musllinux

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -19,6 +19,8 @@ if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   else
     DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
   fi
+elif [[ "$MB_ML_LIBC" == "manylinux" ]] && [[ "$PLAT" == "x86_64" ]]; then
+  DOCKER_TEST_IMAGE="matthewbrett/trusty:64"
 fi
 
 echo "::group::Install a virtualenv"

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "x86_64", "i686" ]
+        platform: [ "i686", "x86_64" ]
         mb-ml-libc: [ "manylinux" ]
         include:
           - python: "3.8"

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -1,4 +1,4 @@
-name: Build Ubuntu wheels
+name: Build Linux wheels
 
 on:
   workflow_call:

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -21,15 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ "3.8", "3.9", "3.10" ]
+        python: [ "3.7", "3.8", "3.9", "3.10", "pypy3.7-7.3.8", "pypy3.8-7.3.8" ]
         platform: [ "arm64", "x86_64" ]
-        include:
+        exclude:
           - python: "3.7"
-            platform: "x86_64"
+            platform: "arm64"
           - python: "pypy3.7-7.3.8"
-            platform: "x86_64"
+            platform: "arm64"
           - python: "pypy3.8-7.3.8"
-            platform: "x86_64"
+            platform: "arm64"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}
       PLAT: ${{ matrix.platform }}

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ "3.7", "3.8", "3.9", "3.10", "pypy3.7-7.3.8", "pypy3.8-7.3.8" ]
-        platform: [ "arm64", "x86_64" ]
+        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
+        platform: [ "x86_64", "arm64" ]
         exclude:
           - python: "3.7"
             platform: "arm64"

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Build macOS wheels
 
 on:
   workflow_call:
@@ -12,44 +12,29 @@ on:
 
 env:
   REPO_DIR: Pillow
-  BUILD_DEPENDS: ""
   TEST_DEPENDS: "pytest pytest-timeout"
-  WHEEL_SDIR: wheelhouse
 
 jobs:
   build:
-    name: ${{ matrix.os-name }} ${{ matrix.python }} ${{ matrix.platform }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.python }} ${{ matrix.platform }}
+    runs-on: "macos-latest"
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
-        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
-        platform: [ "arm64", "x86_64", "i686" ]
-        exclude:
-          - os: "macos-latest"
-            platform: "i686"
-          - os: "macos-latest"
-            platform: "arm64"
-            python: "3.7"
-          - os: "macos-latest"
-            platform: "arm64"
-            python: "pypy3.7-7.3.8"
-          - os: "macos-latest"
-            platform: "arm64"
-            python: "pypy3.8-7.3.8"
-          - os: "ubuntu-20.04"
-            platform: "arm64"
+        python: [ "3.8", "3.9", "3.10" ]
+        platform: [ "arm64", "x86_64" ]
         include:
-          - os: "macos-latest"
-            os-name: "osx"
-          - os: "ubuntu-20.04"
-            os-name: "focal"
+          - platform: "x86_64"
+            python: "3.7"
+          - platform: "x86_64"
+            python: "pypy3.7-7.3.8"
+          - platform: "x86_64"
+            python: "pypy3.8-7.3.8"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
-      TRAVIS_OS_NAME: ${{ matrix.os-name }}
+      TRAVIS_OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -24,12 +24,12 @@ jobs:
         python: [ "3.8", "3.9", "3.10" ]
         platform: [ "arm64", "x86_64" ]
         include:
-          - platform: "x86_64"
-            python: "3.7"
-          - platform: "x86_64"
-            python: "pypy3.7-7.3.8"
-          - platform: "x86_64"
-            python: "pypy3.8-7.3.8"
+          - python: "3.7"
+            platform: "x86_64"
+          - python: "pypy3.7-7.3.8"
+            platform: "x86_64"
+          - python: "pypy3.8-7.3.8"
+            platform: "x86_64"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}
       PLAT: ${{ matrix.platform }}

--- a/.github/workflows/wheels-ubuntu.yml
+++ b/.github/workflows/wheels-ubuntu.yml
@@ -1,0 +1,58 @@
+name: Build Ubuntu wheels
+
+on:
+  workflow_call:
+    inputs:
+      build-commit:
+        required: true
+        type: string
+      artifacts-name:
+        required: true
+        type: string
+
+env:
+  REPO_DIR: Pillow
+  TEST_DEPENDS: "pytest pytest-timeout"
+
+jobs:
+  build:
+    name: ${{ matrix.python }} ${{ matrix.mb-ml-libc }} ${{ matrix.platform }}
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ "pypy3.7-7.3.8", "pypy3.8-7.3.8", "3.7", "3.8", "3.9", "3.10" ]
+        platform: [ "x86_64", "i686" ]
+        mb-ml-libc: [ "manylinux" ]
+        include:
+          - python: "3.8"
+            platform: "x86_64"
+            mb-ml-libc: "musllinux"
+          - python: "3.9"
+            platform: "x86_64"
+            mb-ml-libc: "musllinux"
+          - python: "3.10"
+            platform: "x86_64"
+            mb-ml-libc: "musllinux"
+    env:
+      BUILD_COMMIT: ${{ inputs.build-commit }}
+      PLAT: ${{ matrix.platform }}
+      MB_PYTHON_VERSION: ${{ matrix.python }}
+      MB_ML_LIBC: ${{ matrix.mb-ml-libc }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Build Wheel
+        run: .github/workflows/build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifacts-name }}
+          path: wheelhouse/*.whl
+      # Uncomment to get SSH access for testing
+      # - name: Setup tmate session
+      #   if: failure()
+      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,8 +9,8 @@ jobs:
       build-commit: "HEAD"
       artifacts-name: "wheels"
 
-  ubuntu:
-    uses: ./.github/workflows/wheels-ubuntu.yml
+  linux:
+    uses: ./.github/workflows/wheels-linux.yml
     with:
       build-commit: "HEAD"
       artifacts-name: "wheels"
@@ -22,18 +22,18 @@ jobs:
       build-commit: "main"
       artifacts-name: "wheels-latest"
 
-  ubuntu-latest:
+  linux-latest:
     if: "!startsWith(github.ref, 'refs/tags/')"
-    uses: ./.github/workflows/wheels-ubuntu.yml
+    uses: ./.github/workflows/wheels-linux.yml
     with:
       build-commit: "main"
       artifacts-name: "wheels-latest"
 
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: linux-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [macos, ubuntu]
+    needs: [macos, linux]
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   success:
-    needs: [macos, ubuntu, macos-latest, ubuntu-latest]
+    needs: [macos, linux, macos-latest, linux-latest]
     runs-on: ubuntu-latest
     name: Wheels Successful
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,15 +3,28 @@ name: Wheels
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    uses: ./.github/workflows/wheels-build.yml
+  macos:
+    uses: ./.github/workflows/wheels-macos.yml
     with:
       build-commit: "HEAD"
       artifacts-name: "wheels"
 
-  build-latest:
+  ubuntu:
+    uses: ./.github/workflows/wheels-ubuntu.yml
+    with:
+      build-commit: "HEAD"
+      artifacts-name: "wheels"
+
+  macos-latest:
     if: "!startsWith(github.ref, 'refs/tags/')"
-    uses: ./.github/workflows/wheels-build.yml
+    uses: ./.github/workflows/wheels-macos.yml
+    with:
+      build-commit: "main"
+      artifacts-name: "wheels-latest"
+
+  ubuntu-latest:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    uses: ./.github/workflows/wheels-ubuntu.yml
     with:
       build-commit: "main"
       artifacts-name: "wheels-latest"
@@ -20,7 +33,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: build
+    needs: [macos, ubuntu]
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -32,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   success:
-    needs: [build, build-latest]
+    needs: [macos, ubuntu, macos-latest, ubuntu-latest]
     runs-on: ubuntu-latest
     name: Wheels Successful
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/python-Pillow/Pillow.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/multi-build/multibuild.git
+	url = https://github.com/radarhere/multibuild.git

--- a/config.sh
+++ b/config.sh
@@ -51,7 +51,7 @@ function pre_build {
     untar pillow-depends-main.zip
 
     build_xz
-    if [ -z "$IS_MACOS" ]; then
+    if [ -z "$IS_ALPINE" ] && [ -z "$IS_MACOS" ]; then
         yum remove -y zlib-devel
     fi
     build_new_zlib
@@ -140,7 +140,7 @@ function run_tests_in_repo {
 EXP_CODECS="jpg jpg_2000"
 EXP_CODECS="$EXP_CODECS libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
-if [ -z "$IS_MACOS" ] && [[ "$MB_PYTHON_VERSION" != pypy3* ]] && [[ "$MACHTYPE" != aarch64* ]]; then
+if [ -z "$IS_MACOS" ] && [ -z "$IS_ALPINE" ] && [[ "$MB_PYTHON_VERSION" != pypy3* ]] && [[ "$MACHTYPE" != aarch64* ]]; then
   EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
 else
   # can't find FriBiDi
@@ -156,7 +156,7 @@ function run_tests {
         python3 -m pip install numpy==1.21.4
     elif [[ "$MB_PYTHON_VERSION" == 3.8 || "$MB_PYTHON_VERSION" == 3.9 ]] && [[ $(uname -m) == "i686" ]]; then
         python3 -m pip install numpy==1.21.5
-    else
+    elif [ -z "$IS_ALPINE" ]; then
         python3 -m pip install numpy
     fi
 


### PR DESCRIPTION
Resolves #226. Now that https://github.com/multi-build/multibuild/pull/430 has been merged, we are able to build musllinux wheels.

I'm still waiting on https://github.com/multi-build/multibuild/pull/465 though, so this PR temporarily diverges from the multibuild repository to my fork.

In order to accomodate macOS, manylinux and musllinux wheels, I have rearranged the jobs. Feel completely free to tell me you have a better idea for how to organise them.

As a note to self, it would be worth trying again with numpy after https://github.com/numpy/numpy/pull/21200 makes it into a release.