### PR TITLE
Corrected release runs-on

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
 
   release:
     name: Create Release
-    runs-on: linux-latest
+    runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [macos, linux]
     steps:


### PR DESCRIPTION
I've realised why the "Create release" job hasn't been running - I made a mistake in https://github.com/python-pillow/pillow-wheels/pull/271/commits/2471dbdd757708ab5d29eebc61e6a38198c2bcab