### PR TITLE
Switched back to main multibuild repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/python-Pillow/Pillow.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/radarhere/multibuild.git
+	url = https://github.com/multi-build/multibuild.git


### PR DESCRIPTION
Switches back to the main multibuild repository after #271.

Also updates multibuild to include https://github.com/multi-build/multibuild/pull/467, related to #276