### PR TITLE
Updated zlib on macOS and musllinux to 1.2.12

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -14,9 +14,12 @@ TIFF_VERSION=4.3.0
 LCMS2_VERSION=2.13.1
 if [[ -n "$IS_MACOS" ]]; then
     GIFLIB_VERSION=5.1.4
-    ZLIB_VERSION=1.2.12
 else
     GIFLIB_VERSION=5.2.1
+fi
+if [[ -n "$IS_MACOS" ]] || [[ -n "$IS_ALPINE" ]]; then
+    ZLIB_VERSION=1.2.12
+else
     ZLIB_VERSION=1.2.8
 fi
 LIBWEBP_VERSION=1.2.2
@@ -55,8 +58,10 @@ function pre_build {
         yum remove -y zlib-devel
     fi
 
-    # Workaround for zlib 1.2.12
-    export cc=$CC
+    if [[ -n "$IS_MACOS" ]]; then
+        # Workaround for zlib 1.2.12
+        export cc=$CC
+    fi
     build_new_zlib
 
     if [ -n "$IS_MACOS" ]; then

--- a/config.sh
+++ b/config.sh
@@ -14,7 +14,7 @@ TIFF_VERSION=4.3.0
 LCMS2_VERSION=2.13.1
 if [[ -n "$IS_MACOS" ]]; then
     GIFLIB_VERSION=5.1.4
-    ZLIB_VERSION=1.2.11
+    ZLIB_VERSION=1.2.12
 else
     GIFLIB_VERSION=5.2.1
     ZLIB_VERSION=1.2.8
@@ -54,6 +54,9 @@ function pre_build {
     if [ -z "$IS_ALPINE" ] && [ -z "$IS_MACOS" ]; then
         yum remove -y zlib-devel
     fi
+
+    # Workaround for zlib 1.2.12
+    export cc=$CC
     build_new_zlib
 
     if [ -n "$IS_MACOS" ]; then


### PR DESCRIPTION
- Updated zlib on macOS to 1.2.12. Includes a workaround from https://github.com/madler/zlib/issues/615. Without the workaround, [an error occurs](https://github.com/radarhere/pillow-wheels/runs/5802112765) after zlib tries to build libz.so.1.2.12 instead of libz.1.2.12.dylib.
- Updated zlib on musllinux to 1.2.12. zlib was downgraded to 1.2.8 in #254, because of restrictions in [auditwheel's manylinux-policy.json](https://github.com/pypa/auditwheel/blob/main/src/auditwheel/policy/manylinux-policy.json), but there are no such restrictions in [musllinux-policy.json](https://github.com/pypa/auditwheel/blob/main/src/auditwheel/policy/musllinux-policy.json).