### PR TITLE
Fixed setting MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -6,9 +6,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php
 
   if [[ "$PLAT" == "arm64" ]]; then
-    MACOSX_DEPLOYMENT_TARGET="11.0"
+    export MACOSX_DEPLOYMENT_TARGET="11.0"
   else
-    MACOSX_DEPLOYMENT_TARGET="10.10"
+    export MACOSX_DEPLOYMENT_TARGET="10.10"
   fi
 fi
 


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/6179

If you look at the artifacts generated before https://github.com/python-pillow/pillow-wheels/pull/265, in https://github.com/python-pillow/pillow-wheels/actions/runs/2008816167 you see Pillow-9.0.1-cp38-cp38-macosx_10_10_x86_64.whl.
After that PR, in https://github.com/python-pillow/pillow-wheels/actions/runs/2011383640 you see Pillow-9.0.1-cp38-cp38-macosx_10_9_x86_64.whl.

So despite the fact that the PR was only intended to rearrange the jobs, there was a change. This is because in moving `MACOSX_DEPLOYMENT_TARGET`, I managed to break it. This is fixed here using `export`, and you can see that this PR generates Pillow-9.1.0-cp38-cp38-macosx_10_10_x86_64.whl again.