### PR TITLE
Fixed restoring original CFLAGS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -100,6 +100,7 @@ function pre_build {
     build_lcms2
     build_openjpeg
 
+    ORIGINAL_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
     build_libwebp
     CFLAGS=$ORIGINAL_CFLAGS


### PR DESCRIPTION
https://github.com/python-pillow/pillow-wheels/blob/68b95e37829260aee8312069332ca76ce7717a11/config.sh#L105

`$ORIGINAL_CFLAGS` is not defined. It was removed in #237, as I missed that it was still in use. This PR restores it.