### PR TITLE
Removed symlink as Pillow now checks /usr/local/lib/libfribidi.dylib

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -160,7 +160,6 @@ function run_tests {
         echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
 
         brew install fribidi
-        ln -s /usr/local/lib/libfribidi.dylib libfribidi.dylib
     elif [ -n "$IS_ALPINE" ]; then
         apk add fribidi
     fi


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/6182 means that Pillow now checks /usr/local/lib/libfribidi.dylib.
So /usr/local/lib/libfribidi.dylib no longer needs to be symlinked to be found.

This will fail HEAD builds for now.