### PR TITLE
Test 64-bit manylinux on default focal

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -19,8 +19,6 @@ if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   else
     DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
   fi
-elif [[ "$MB_ML_LIBC" == "manylinux" ]] && [[ "$PLAT" == "x86_64" ]]; then
-  DOCKER_TEST_IMAGE="matthewbrett/trusty:64"
 fi
 
 echo "::group::Install a virtualenv"

--- a/config.sh
+++ b/config.sh
@@ -147,12 +147,7 @@ function run_tests_in_repo {
 
 EXP_CODECS="jpg jpg_2000 libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
-if ([ -n "$IS_MACOS" ] || [[ "$MB_PYTHON_VERSION" != pypy3* ]]) && [[ "$MACHTYPE" != aarch64* ]]; then
-  EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
-else
-  # can't find FriBiDi
-  EXP_FEATURES="libjpeg_turbo transp_webp webp_anim webp_mux xcb"
-fi
+EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
 
 function run_tests {
     if [ -n "$IS_MACOS" ]; then
@@ -163,6 +158,8 @@ function run_tests {
         ln -s /usr/local/lib/libfribidi.dylib libfribidi.dylib
     elif [ -n "$IS_ALPINE" ]; then
         apk add fribidi
+    else
+        apt-get install libfribidi0
     fi
     if [[ "$MB_PYTHON_VERSION" == pypy3.* || "$MB_PYTHON_VERSION" == 3.10 ]] && [[ $(uname -m) == "i686" ]]; then
         python3 -m pip install numpy==1.21.4


### PR DESCRIPTION
https://github.com/multi-build/multibuild/pull/433 switched the default 64-bit manylinux test image to focal. This PR removes our custom setting for the test images, allowing that default to be used.

By itself, that change means that fribidi is no longer found when testing. I presumed that was due to a configuration difference between [matthew-brett/trusty](https://github.com/matthew-brett/trusty) and [multi-build/docker-images](https://github.com/multi-build/docker-images). It turns out that the official "ubuntu:14.04" image already has fribidi installed, but this is removed from 16.04 onwards. So instead, I install fribidi, finally meaning that pillow-wheels can test fribidi in all environments.