### PR TITLE
Cleanup code

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -29,13 +29,13 @@ echo "::group::Install a virtualenv"
 echo "::endgroup::"
 
 echo "::group::Build wheel"
-  clean_code $REPO_DIR $BUILD_COMMIT
-  build_wheel $REPO_DIR $PLAT
+  clean_code
+  build_wheel
   ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
 echo "::endgroup::"
 
 if [[ $MACOSX_DEPLOYMENT_TARGET != "11.0" ]]; then
   echo "::group::Test wheel"
-    install_run $PLAT
+    install_run
   echo "::endgroup::"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
       - PLAT=aarch64
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
+      - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
       - TEST_DEPENDS="pytest pytest-timeout"
 
 language: python
@@ -19,25 +20,21 @@ jobs:
       arch: arm64
       env:
         - MB_PYTHON_VERSION=3.7
-        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.8 Focal aarch64"
       os: linux
       arch: arm64
       env:
         - MB_PYTHON_VERSION=3.8
-        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.9 Focal aarch64"
       os: linux
       arch: arm64
       env:
         - MB_PYTHON_VERSION=3.9
-        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.10 Focal aarch64"
       os: linux
       arch: arm64
       env:
         - MB_PYTHON_VERSION=3.10
-        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
 
 before_install:
     - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
       - BUILD_COMMIT=HEAD
       - PLAT=aarch64
       - UNICODE_WIDTH=32
-      - BUILD_DEPENDS=""
       - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
       - TEST_DEPENDS="pytest pytest-timeout"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ before_install:
 
 install:
     # Maybe get and clean and patch source
-    - clean_code $REPO_DIR $BUILD_COMMIT
-    - build_wheel $REPO_DIR $PLAT
+    - clean_code
+    - build_wheel
     - ls -l "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/"
 
 script:
-    - install_run $PLAT
+    - install_run
 
 # Upload wheels to GitHub Releases
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ env:
       - REPO_DIR=Pillow
       - BUILD_COMMIT=HEAD
       - PLAT=aarch64
-      - UNICODE_WIDTH=32
       - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
       - TEST_DEPENDS="pytest pytest-timeout"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
   global:
       - REPO_DIR=Pillow
       - BUILD_COMMIT=HEAD
-      - PLAT=x86_64
+      - PLAT=aarch64
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
       - TEST_DEPENDS="pytest pytest-timeout"
@@ -18,28 +18,24 @@ jobs:
     - name: "3.7 Focal aarch64"
       arch: arm64
       env:
-        - PLAT=aarch64
         - MB_PYTHON_VERSION=3.7
         - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.8 Focal aarch64"
       os: linux
       arch: arm64
       env:
-        - PLAT=aarch64
         - MB_PYTHON_VERSION=3.8
         - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.9 Focal aarch64"
       os: linux
       arch: arm64
       env:
-        - PLAT=aarch64
         - MB_PYTHON_VERSION=3.9
         - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
     - name: "3.10 Focal aarch64"
       os: linux
       arch: arm64
       env:
-        - PLAT=aarch64
         - MB_PYTHON_VERSION=3.10
         - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ before_install:
 
 install:
     # Maybe get and clean and patch source
-    - if [[ -n "$LATEST" ]]; then BUILD_COMMIT=main; fi
     - clean_code $REPO_DIR $BUILD_COMMIT
     - build_wheel $REPO_DIR $PLAT
     - ls -l "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/"
@@ -65,6 +64,5 @@ deploy:
   file_glob: true
   file: "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/*.whl"
   on:
-    condition: -z "$LATEST"
     repo: python-pillow/pillow-wheels
   skip_cleanup: true


### PR DESCRIPTION
This PR has a few commits cleaning up the Travis matrix
- `LATEST` is never set, so I've removed checks for it
- Travis `PLAT` is always "aarch64", so I've moved the configuration into the global section
- `DOCKER_TEST_IMAGE` is always "multibuild/focal_{PLAT}", so I've moved the configuration into the global section

And a few commits removing defaults
- `BUILD_DEPENDS` is [empty by default](https://github.com/multi-build/multibuild/blob/d0fdfdd42d1dfb82be1b7bddf185dd6a1c287bf8/common_utils.sh#L311), so this PR no longer specifies it as empty.
- `UNICODE_WIDTH` is [32 by default](https://github.com/multi-build/multibuild/blob/d0fdfdd42d1dfb82be1b7bddf185dd6a1c287bf8/common_utils.sh#L25), so this PR no longer specifies it as 32.
- `clean_code` uses `REPO_DIR` and `BUILD_COMMIT` as [defaults](https://github.com/multi-build/multibuild/blob/d0fdfdd42d1dfb82be1b7bddf185dd6a1c287bf8/common_utils.sh#L282-L284), so they don't need to be passed to it.
- `build_wheel` has `REPO_DIR` and `PLAT` as [defaults](https://github.com/multi-build/multibuild/blob/d0fdfdd42d1dfb82be1b7bddf185dd6a1c287bf8/travis_linux_steps.sh#L42-L44), so they don't need to be passed to it.
- `install_run` has `PLAT` as a [default](https://github.com/multi-build/multibuild/blob/d0fdfdd42d1dfb82be1b7bddf185dd6a1c287bf8/travis_linux_steps.sh#L120), so it doesn't need to be passed to it.