### PR TITLE
multibuild now considers PLAT when selecting focal test images

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -16,8 +16,6 @@ if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   MB_PYTHON_OSX_VER="10.9"
   if [[ "$PLAT" == "i686" ]]; then
     DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
-  else
-    DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"
   fi
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ env:
       - REPO_DIR=Pillow
       - BUILD_COMMIT=HEAD
       - PLAT=aarch64
-      - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
       - TEST_DEPENDS="pytest pytest-timeout"
 
 language: python


### PR DESCRIPTION
Updates multibuild to include https://github.com/multi-build/multibuild/pull/468, allowing our `DOCKER_TEST_IMAGE="multibuild/focal_$PLAT"` settings to be removed.