### PR TITLE
brew remove lcms2 xmlto ghostscript

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -3,7 +3,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # webp, zstd, xz, libtiff, libxcb cause a conflict with building webp, libtiff, libxcb
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php
+  # remove lcms2 to fix building openjpeg on arm64
+  # remove xmlto to skip building giflib docs
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php lcms2 xmlto
 
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -5,7 +5,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # if php is installed, brew tries to reinstall these after installing openblas
   # remove lcms2 to fix building openjpeg on arm64
   # remove xmlto to skip building giflib docs
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php lcms2 xmlto
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php lcms2 xmlto ghostscript
 
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"


### PR DESCRIPTION
macOS builds have started failing - https://github.com/python-pillow/pillow-wheels/actions/runs/2318590890

The arm64 build is failing while [building openjpeg](https://github.com/python-pillow/pillow-wheels/runs/6420505605?check_suite_focus=true#step:4:4545). `brew remove lcms2` fixes this.
The x86_64 build is failing while [reading XML as part of building the giflib docs](https://github.com/python-pillow/pillow-wheels/runs/6420505515?check_suite_focus=true#step:4:4711). If the XML tool, `xmlto`, is absent though, giflib doesn't try to build its docs, so `brew remove xmlto` fixes this.

[After that](https://github.com/radarhere/pillow-wheels/commit/60f497ffeac6c305f24a5964000707bda4e1ed1c), the build process completes, but [there is an error when the tests invoke ghostscript](https://github.com/radarhere/pillow-wheels/runs/6423551651?check_suite_focus=true#step:4:6317). However, [since the last passing Ci run didn't have ghostscript](https://github.com/python-pillow/pillow-wheels/runs/6364336121?check_suite_focus=true#step:4:6444), it isn't a step backwards to also remove that.