### PR TITLE
Deploy to GitHub Releases when a tag is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,5 @@ deploy:
   file: "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/*.whl"
   on:
     repo: python-pillow/pillow-wheels
+    tags: true
   skip_cleanup: true


### PR DESCRIPTION
Fixes https://github.com/python-pillow/pillow-wheels/issues/295.

Builds for branches and tags, only deploys on tags.

If we want to still deploy for tags, can look into that too.