### PR TITLE
Updated auditwheel to include auditwheel#376

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -140,6 +140,9 @@ function pre_build {
 }
 
 function pip_wheel_cmd {
+    git clone https://github.com/pypa/auditwheel
+    (cd auditwheel && git checkout fe45465 && pipx install --force .)
+
     local abs_wheelhouse=$1
     if [ -z "$IS_MACOS" ]; then
         CFLAGS="$CFLAGS --std=c99"  # for Raqm


### PR DESCRIPTION
Resolves https://github.com/python-pillow/pillow-wheels/issues/299

The issue reports that "ELF load command address/offset not page-aligned" may occur when using Pillow after it is stripped by pyinstaller.

I discovered point 3 of https://github.com/pypa/auditwheel/pull/376, and upgrading auditwheel to include that PR, the problem is resolved.