### PR TITLE
Added manylinux_2_28

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.python }} ${{ matrix.mb-ml-libc }} ${{ matrix.platform }}
+    name: ${{ matrix.python }} ${{ matrix.mb-ml-libc }}${{ matrix.mb-ml-ver }} ${{ matrix.platform }}
     runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: false
@@ -24,21 +24,29 @@ jobs:
         python: [ "pypy3.7-7.3.9", "pypy3.8-7.3.9", "3.7", "3.8", "3.9", "3.10" ]
         platform: [ "i686", "x86_64" ]
         mb-ml-libc: [ "manylinux" ]
+        mb-ml-ver: [ 2014, "_2_28" ]
+        exclude:
+          - platform: "i686"
+            mb-ml-ver: "_2_28"
         include:
           - python: "3.8"
             platform: "x86_64"
             mb-ml-libc: "musllinux"
+            mb-ml-ver: "_1_1"
           - python: "3.9"
             platform: "x86_64"
             mb-ml-libc: "musllinux"
+            mb-ml-ver: "_1_1"
           - python: "3.10"
             platform: "x86_64"
             mb-ml-libc: "musllinux"
+            mb-ml-ver: "_1_1"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
       MB_ML_LIBC: ${{ matrix.mb-ml-libc }}
+      MB_ML_VER: ${{ matrix.mb-ml-ver }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,24 +13,51 @@ services: docker
 
 jobs:
   include:
-    - name: "3.7 Focal aarch64"
+    - name: "3.7 Focal manylinux2014 aarch64"
       arch: arm64
       env:
+        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.7
-    - name: "3.8 Focal aarch64"
+    - name: "3.7 Focal manylinux_2_28 aarch64"
+      arch: arm64
+      env:
+        - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.7
+    - name: "3.8 Focal manylinux2014 aarch64"
       os: linux
       arch: arm64
       env:
+        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.8
-    - name: "3.9 Focal aarch64"
+    - name: "3.8 Focal manylinux_2_28 aarch64"
       os: linux
       arch: arm64
       env:
+        - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.8
+    - name: "3.9 Focal manylinux2014 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.9
-    - name: "3.10 Focal aarch64"
+    - name: "3.9 Focal manylinux_2_28 aarch64"
       os: linux
       arch: arm64
       env:
+        - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.9
+    - name: "3.10 Focal manylinux2014 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.10
+    - name: "3.10 Focal manylinux_2_28 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_2_28"
         - MB_PYTHON_VERSION=3.10
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -17,7 +17,7 @@ if [[ -n "$IS_MACOS" ]]; then
 else
     GIFLIB_VERSION=5.2.1
 fi
-if [[ -n "$IS_MACOS" ]] || [[ -n "$IS_ALPINE" ]]; then
+if [[ -n "$IS_MACOS" ]] || [[ "$MB_ML_VER" != 2014 ]]; then
     ZLIB_VERSION=1.2.12
 else
     ZLIB_VERSION=1.2.8


### PR DESCRIPTION
Adds manylinux_2_28 wheels for x86_64 and aarch64 ([manylinux has not provided an image for i686](https://github.com/pypa/manylinux#manylinux_2_28-almalinux-8-based)).

This allows for zlib 1.2.12, rather than just 1.2.8.

We should keep the manylinux 2014 (a.k.a _2_17) wheels around as they provide support for [CentOS 7 and Amazon Linux 2.](https://github.com/python-pillow/pillow-wheels/pull/254#issue-1139500602)