### PR TITLE
Added Python 3.11.0b3

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -19,6 +19,8 @@ if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
   if [[ "$PLAT" == "i686" ]]; then
     DOCKER_TEST_IMAGE="multibuild/xenial_$PLAT"
   fi
+elif [[ "$MB_PYTHON_VERSION" == "3.11" ]] && [[ "$PLAT" == "i686" ]]; then
+  DOCKER_TEST_IMAGE="radarhere/bionic-$PLAT"
 fi
 
 echo "::group::Install a virtualenv"

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ "pypy3.7-7.3.9", "pypy3.8-7.3.9", "3.7", "3.8", "3.9", "3.10" ]
+        python: [ "pypy3.7-7.3.9", "pypy3.8-7.3.9", "3.7", "3.8", "3.9", "3.10", "3.11" ]
         platform: [ "i686", "x86_64" ]
         mb-ml-libc: [ "manylinux" ]
         mb-ml-ver: [ 2014, "_2_28" ]
@@ -38,6 +38,10 @@ jobs:
             mb-ml-libc: "musllinux"
             mb-ml-ver: "_1_1"
           - python: "3.10"
+            platform: "x86_64"
+            mb-ml-libc: "musllinux"
+            mb-ml-ver: "_1_1"
+          - python: "3.11"
             platform: "x86_64"
             mb-ml-libc: "musllinux"
             mb-ml-ver: "_1_1"

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ "pypy3.7-7.3.9", "pypy3.8-7.3.9", "3.7", "3.8", "3.9", "3.10" ]
+        python: [ "pypy3.7-7.3.9", "pypy3.8-7.3.9", "3.7", "3.8", "3.9", "3.10", "3.11" ]
         platform: [ "x86_64", "arm64" ]
         exclude:
           - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,18 @@ jobs:
       env:
         - MB_ML_VER="_2_28"
         - MB_PYTHON_VERSION=3.10
+    - name: "3.11 Focal manylinux_2_28 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.11
+    - name: "3.11 Focal manylinux_2_28 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.11
 
 before_install:
     - source multibuild/common_utils.sh

--- a/config.sh
+++ b/config.sh
@@ -143,6 +143,8 @@ function pip_wheel_cmd {
     local abs_wheelhouse=$1
     if [ -z "$IS_MACOS" ]; then
         CFLAGS="$CFLAGS --std=c99"  # for Raqm
+    elif [[ "$MB_PYTHON_VERSION" == "3.11" ]]; then
+        unset _PYTHON_HOST_PLATFORM
     fi
     pip wheel $(pip_opts) \
         --global-option build_ext --global-option --enable-raqm \
@@ -173,8 +175,10 @@ function run_tests {
         apt-get install libfribidi0
     fi
     if [[ $(uname -m) == "i686" ]]; then
-        python3 -m pip install numpy==1.21
-    elif [ -z "$IS_ALPINE" ]; then
+        if [[ "$MB_PYTHON_VERSION" != 3.11 ]]; then
+            python3 -m pip install numpy==1.21
+        fi
+    elif [ -z "$IS_ALPINE" ] && !([ -n "$IS_MACOS" ] && [[ "$MB_PYTHON_VERSION" == 3.11 ]]); then
         python3 -m pip install numpy
     fi
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/6367

While I have created https://github.com/multi-build/multibuild/pull/477 and https://github.com/multi-build/docker-images/pull/35, they haven't been merged yet. While https://github.com/matthew-brett/trusty/pull/20 has been merged, [the 32-bit docker image hasn't been updated.](https://hub.docker.com/r/matthewbrett/trusty/tags)

So instead, this PR patches `fill_pyver` to cover the multibuild functionality, and switches to using my account for Python 3.11 docker test images.