### PR TITLE
Use python3 when calling twine

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ Download wheels from the
 `latest release <https://github.com/python-pillow/pillow-wheels/releases>`_ and upload
 to PyPI::
 
-    twine upload Pillow-<VERSION>-*
+    python3 -m twine upload Pillow-<VERSION>-*


### PR DESCRIPTION
In the same line of thinking as https://github.com/python-pillow/Pillow/commit/48a65656eea5e18a031e992ce65553f338fae902