### PR TITLE
Updated multibuild to include build_giflib for giflib >= 5.1.5

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -26,27 +26,6 @@ LIBWEBP_VERSION=1.2.4
 BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.14
 
-function build_giflib {
-    local name=giflib
-    local version=$GIFLIB_VERSION
-    local url=https://downloads.sourceforge.net/project/giflib
-    if [ $(lex_ver $GIFLIB_VERSION) -lt $(lex_ver 5.1.5) ]; then
-        build_simple $name $version $url
-    else
-        local ext=tar.gz
-        if [ -e "${name}-stamp" ]; then
-            return
-        fi
-        local name_version="${name}-${version}"
-        local archive=${name_version}.${ext}
-        fetch_unpack $url/$archive
-        (cd $name_version \
-            && make -j4 \
-            && make install)
-        touch "${name}-stamp"
-    fi
-}
-
 if [[ -n "$IS_MACOS" ]] && [[ "$PLAT" == "x86_64" ]]; then
     function build_openjpeg {
         local out_dir=$(fetch_unpack https://github.com/uclouvain/openjpeg/archive/v${OPENJPEG_VERSION}.tar.gz)


### PR DESCRIPTION
Updated multibuild to include https://github.com/multi-build/multibuild/pull/449. This means that the custom `build_giflib` function I added in #245 is now part of multibuild.