### PR TITLE
NumPy now supports Python 3.11

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -157,7 +157,7 @@ function run_tests {
         if [[ "$MB_PYTHON_VERSION" != 3.11 ]]; then
             python3 -m pip install numpy==1.21
         fi
-    elif [ -z "$IS_ALPINE" ] && !([ -n "$IS_MACOS" ] && [[ "$MB_PYTHON_VERSION" == 3.11 ]]); then
+    elif [ -z "$IS_ALPINE" ]; then
         python3 -m pip install numpy
     fi
 


### PR DESCRIPTION
NumPy now supports Python 3.11 - https://github.com/numpy/numpy/releases/tag/v1.23.2