### PR TITLE
Restored _PYTHON_HOST_PLATFORM for Python 3.11

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -123,8 +123,6 @@ function pip_wheel_cmd {
     local abs_wheelhouse=$1
     if [ -z "$IS_MACOS" ]; then
         CFLAGS="$CFLAGS --std=c99"  # for Raqm
-    elif [[ "$MB_PYTHON_VERSION" == "3.11" ]]; then
-        unset _PYTHON_HOST_PLATFORM
     fi
     pip wheel $(pip_opts) \
         --global-option build_ext --global-option --enable-raqm \


### PR DESCRIPTION
#316 has found that the macOS Python 3.11 job is naming its wheels as universal2, rather than arm64 wheels like the other macOS jobs.

Part of #302 removed the `_PYTHON_HOST_PLATFORM` for Python 3.11. Looking back through my repository's builds, I apparently did this to avoid a delocate error.

That error no longer occurs, so this can be removed.