### PR TITLE
Updated Python 3.11 to rc1

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -26,6 +26,7 @@ fi
 echo "::group::Install a virtualenv"
   source multibuild/common_utils.sh
   source multibuild/travis_steps.sh
+  export LATEST_3p11="3.11.0rc1"
   python3 -m pip install virtualenv
   before_install
 echo "::endgroup::"


### PR DESCRIPTION
If #316 is interested in uploading new Python 3.11 wheels to PyPI, better to do it with the most recent version.

This PR overrides multibuild, which is [currently at b5](https://github.com/multi-build/multibuild/blob/85467f2c27ce82519ba763932e0d94d1b43edbf5/osx_utils.sh#L23). This can be seen in our current build - ["checking for python version... 3.11.0b5"](https://github.com/python-pillow/pillow-wheels/runs/8128516924?check_suite_focus=true#step:4:5458)