### PR TITLE
Added brotli

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -25,6 +25,7 @@ fi
 LIBWEBP_VERSION=1.2.4
 BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.14
+BROTLI_VERSION=1.0.9
 
 if [[ -n "$IS_MACOS" ]] && [[ "$PLAT" == "x86_64" ]]; then
     function build_openjpeg {
@@ -35,6 +36,14 @@ if [[ -n "$IS_MACOS" ]] && [[ "$PLAT" == "x86_64" ]]; then
         touch openjpeg-stamp
     }
 fi
+
+function build_brotli {
+    local cmake=$(get_modern_cmake)
+    local out_dir=$(fetch_unpack https://github.com/google/brotli/archive/v$BROTLI_VERSION.tar.gz)
+    (cd $out_dir \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && make install)
+}
 
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
@@ -92,9 +101,11 @@ function pre_build {
     build_libwebp
     CFLAGS=$ORIGINAL_CFLAGS
 
+    build_brotli
+
     if [ -n "$IS_MACOS" ]; then
         # Custom freetype build
-        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no --with-brotli=no
+        build_simple freetype $FREETYPE_VERSION https://download.savannah.gnu.org/releases/freetype tar.gz --with-harfbuzz=no
     else
         build_freetype
     fi

--- a/dependency_licenses/BROTLI.txt
+++ b/dependency_licenses/BROTLI.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/6554 by adding brotli.

After building brotli, delocate was unable to find the dependencies. I solved this by passing in `/usr/local/lib` through `DYLD_LIBRARY_PATH`, which allowed me to remove the custom `build_openjpeg` added in #294.