### PR TITLE
Updated Python 3.11 to rc2

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -26,7 +26,7 @@ fi
 echo "::group::Install a virtualenv"
   source multibuild/common_utils.sh
   source multibuild/travis_steps.sh
-  export LATEST_3p11="3.11.0rc1"
+  export LATEST_3p11="3.11.0rc2"
   python3 -m pip install virtualenv
   before_install
 echo "::endgroup::"


### PR DESCRIPTION
Python 3.11.0rc2 has been released - https://www.python.org/downloads/release/python-3110rc2/