### PR TITLE
Updated auditwheel to 5.2.0

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -127,9 +127,6 @@ function pre_build {
 }
 
 function pip_wheel_cmd {
-    git clone https://github.com/pypa/auditwheel
-    (cd auditwheel && git checkout fe45465 && pipx install --force .)
-
     local abs_wheelhouse=$1
     if [ -z "$IS_MACOS" ]; then
         CFLAGS="$CFLAGS --std=c99"  # for Raqm


### PR DESCRIPTION
Reverts the inclusion of a commit-specific version auditwheel from #298 now that [auditwheel 5.2.0](https://github.com/pypa/auditwheel/releases/tag/5.2.0) has been released