### PR TITLE
Specify Python version in Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Resolves warnings that occur at the moment.

https://github.com/python-pillow/pillow-wheels/actions/runs/3375616727/jobs/5602423188#step:3:7
> Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
> Warning: .python-version doesn't exist.
> Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.