### PR TITLE
Do not install OpenBLAS on macOS for NumPy

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -149,9 +149,6 @@ EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux
 
 function run_tests {
     if [ -n "$IS_MACOS" ]; then
-        brew install openblas
-        echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
-
         brew install fribidi
     elif [ -n "$IS_ALPINE" ]; then
         apk add fribidi


### PR DESCRIPTION
Partially reverts https://github.com/python-pillow/pillow-wheels/pull/154/commits/505e915516def3757a6b627f6e8907a73a36cb0f, as a companion to https://github.com/python-pillow/Pillow/pull/6727 reverting https://github.com/python-pillow/Pillow/pull/4711