### PR TITLE
Updated TravisCI to Python 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 language: python
 # Default Python version is usually 3.6
-python: "3.10"
+python: "3.11"
 dist: focal
 services: docker
 


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/issues/6575

https://travis-ci.community/t/please-add-image-for-python-3-11/13384/3 states that Python 3.11 has been added to Travis.