### PR TITLE
Added musllinux aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ jobs:
       env:
         - MB_ML_VER="_2_28"
         - MB_PYTHON_VERSION=3.8
+    - name: "3.8 musllinux_1_1 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_1_1"
+        - MB_ML_LIBC="musllinux"
+        - MB_PYTHON_VERSION=3.8
     - name: "3.9 Focal manylinux2014 aarch64"
       os: linux
       arch: arm64
@@ -46,6 +53,13 @@ jobs:
       arch: arm64
       env:
         - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.9
+    - name: "3.9 musllinux_1_1 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_1_1"
+        - MB_ML_LIBC="musllinux"
         - MB_PYTHON_VERSION=3.9
     - name: "3.10 Focal manylinux2014 aarch64"
       os: linux
@@ -59,6 +73,13 @@ jobs:
       env:
         - MB_ML_VER="_2_28"
         - MB_PYTHON_VERSION=3.10
+    - name: "3.10 musllinux_1_1 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_1_1"
+        - MB_ML_LIBC="musllinux"
+        - MB_PYTHON_VERSION=3.10
     - name: "3.11 Focal manylinux_2_28 aarch64"
       os: linux
       arch: arm64
@@ -70,6 +91,13 @@ jobs:
       arch: arm64
       env:
         - MB_ML_VER="_2_28"
+        - MB_PYTHON_VERSION=3.11
+    - name: "3.11 musllinux_1_1 aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - MB_ML_VER="_1_1"
+        - MB_ML_LIBC="musllinux"
         - MB_PYTHON_VERSION=3.11
 
 before_install:


### PR DESCRIPTION
Resolves #346 by adding musllinux aarch64 wheels.

Temporarily specifies `DOCKER_TEST_IMAGE`, until https://github.com/multi-build/multibuild/pull/487 is merged.