### PR TITLE
Updated PyPy to 7.3.11

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          "pypy3.8-7.3.10",
-          "pypy3.9-7.3.10",
+          "pypy3.8-7.3.11",
+          "pypy3.9-7.3.11",
           "3.7",
           "3.8",
           "3.9",

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          "pypy3.8-7.3.10",
-          "pypy3.9-7.3.10",
+          "pypy3.8-7.3.11",
+          "pypy3.9-7.3.11",
           "3.7",
           "3.8",
           "3.9",
@@ -34,9 +34,9 @@ jobs:
         exclude:
           - python: "3.7"
             platform: "arm64"
-          - python: "pypy3.8-7.3.10"
+          - python: "pypy3.8-7.3.11"
             platform: "arm64"
-          - python: "pypy3.9-7.3.10"
+          - python: "pypy3.9-7.3.11"
             platform: "arm64"
     env:
       BUILD_COMMIT: ${{ inputs.build-commit }}

--- a/config.sh
+++ b/config.sh
@@ -144,11 +144,7 @@ function run_tests_in_repo {
 }
 
 EXP_CODECS="jpg jpg_2000 libtiff zlib"
-if [[ "$MB_PYTHON_VERSION" == pypy3.* ]] && [ -n "$IS_MACOS" ]; then
-    EXP_MODULES="freetype2 littlecms2 pil webp"
-else
-    EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
-fi
+EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
 EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
 
 function run_tests {


### PR DESCRIPTION
PyPy 7.3.11 has been released - https://doc.pypy.org/en/latest/release-v7.3.11.html

https://foss.heptapod.net/pypy/pypy/-/issues/3868 was closed, so https://github.com/hugovk/pillow-wheels/pull/7 can be reverted, enabling tkinter on macOS PyPy again.