### PR TITLE
Downgrade libXau to 1.0.10 when targeting macOS 10.10

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -6,12 +6,6 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # remove lcms2 to fix building openjpeg on arm64
   # remove xmlto to skip building giflib docs
   brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php lcms2 xmlto ghostscript
-
-  if [[ "$PLAT" == "arm64" ]]; then
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
-  else
-    export MACOSX_DEPLOYMENT_TARGET="10.10"
-  fi
 fi
 
 if [[ "$MB_PYTHON_VERSION" == pypy3* ]]; then
@@ -36,7 +30,7 @@ echo "::group::Build wheel"
   ls -l "${GITHUB_WORKSPACE}/${WHEEL_SDIR}/"
 echo "::endgroup::"
 
-if [[ $MACOSX_DEPLOYMENT_TARGET != "11.0" ]]; then
+if [[ $PLAT != "arm64" ]]; then
   echo "::group::Test wheel"
     install_run
   echo "::endgroup::"

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.python }} ${{ matrix.platform }}
+    name: ${{ matrix.python }} macOS ${{ matrix.target }} ${{ matrix.platform }}
     runs-on: "macos-latest"
     strategy:
       fail-fast: false
@@ -30,10 +30,22 @@ jobs:
           "3.10",
           "3.11",
         ]
+        target: [ "10.10", "11.0" ]
         platform: [ "x86_64", "arm64" ]
         exclude:
+          - target: "10.10"
+            platform: "arm64"
           - python: "3.7"
             platform: "arm64"
+          - python: "3.7"
+            target: "11.0"
+            platform: "x86_64"
+          - python: "3.8"
+            target: "11.0"
+            platform: "x86_64"
+          - python: "3.9"
+            target: "11.0"
+            platform: "x86_64"
           - python: "pypy3.8-7.3.11"
             platform: "arm64"
           - python: "pypy3.9-7.3.11"
@@ -43,6 +55,7 @@ jobs:
       PLAT: ${{ matrix.platform }}
       MB_PYTHON_VERSION: ${{ matrix.python }}
       TRAVIS_OS_NAME: "osx"
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/config.sh
+++ b/config.sh
@@ -4,6 +4,11 @@
 ARCHIVE_SDIR=pillow-depends-main
 
 # Package versions for fresh source builds
+if [[ -n "$IS_MACOS" ]] && [[ $MACOSX_DEPLOYMENT_TARGET == "10.10" ]]; then
+    LIBXAU_VERSION=1.0.10
+else
+    LIBXAU_VERSION=1.0.11
+fi
 FREETYPE_VERSION=2.12.1
 HARFBUZZ_VERSION=6.0.0
 LIBPNG_VERSION=1.6.39
@@ -70,7 +75,7 @@ function pre_build {
     build_simple xcb-proto 1.15.2 https://xcb.freedesktop.org/dist
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2022.2 https://www.x.org/pub/individual/proto
-        build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
+        build_simple libXau $LIBXAU_VERSION https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.4 https://xcb.freedesktop.org/dist
         cp venv/share/pkgconfig/xcb-proto.pc venv/lib/pkgconfig/xcb-proto.pc
     else


### PR DESCRIPTION
Since Pillow 9.4.0, users have reported an error on macOS [10.13](https://github.com/python-pillow/Pillow/issues/6179#issuecomment-1369629676) and [10.14](https://github.com/python-pillow/Pillow/issues/3068#issuecomment-1368856679).

When homebrew updated libXau 1.0.11, [they removed support for 10.15](https://github.com/Homebrew/homebrew-core/commit/712726ca875be4f7528c5288c48214ec7078ae99), so I wondered if #350 updating libXau to 1.0.11 was the cause. [Reverting to an earlier version of libXau](https://github.com/python-pillow/Pillow/issues/6179#issuecomment-1369633528) indeed [fixed the problem.](https://github.com/python-pillow/Pillow/issues/6179#issuecomment-1369639342)

Here is a possible workaround.

At the moment, Pillow builds wheels for macOS 10.10 and above for x86-64 (macosx_10_10_x86_64.whl) and for macOS 11 and above for arm64 (macosx_11_0_arm64.whl).
If libXau 1.0.11 is only supported on macOS 11, then adding a macOS 11 x86-64 wheel would allow us to specifically target macOS < 11, so that libXau 1.0.11 could still be used on the latest macOS versions, and macOS < 11 could use libXau 1.0.10.

However, when testing this, i found "[ERROR: Pillow-9.4.0-cp37-cp37m-macosx_11_0_x86_64.whl is not a supported wheel on this platform.](https://github.com/radarhere/pillow-wheels/actions/runs/3833379424/jobs/6524778021#step:4:6810)" for Python 3.7, 3.8 and 3.9. So since specific wheels can't be created for those Python versions, macOS x86-64 wheels for Python 3.7, 3.8 and 3.9 will just have downgraded libXau.

In summary, this PR will
- downgrade to libXau 1.0.10 for macOS < 11, fixing the reported problems
- unfortunately also downgrade to libXau 1.0.10 for 64-bit macOS >= 11 Python 3.7, 3.8 and 3.9
- keep libXau 1.0.11 for macOS arm64, and macOS 64-bit Python 3.10 and 3.11