### PR TITLE
Remove libxdmcp instead of downgrading libXau

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,11 +1,12 @@
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # webp, zstd, xz, libtiff, libxcb cause a conflict with building webp, libtiff, libxcb
+  # libxdmcp causes an issue on macOS < 11
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
   # remove lcms2 to fix building openjpeg on arm64
   # remove xmlto to skip building giflib docs
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb curl php lcms2 xmlto ghostscript
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php lcms2 xmlto ghostscript
 
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"

--- a/config.sh
+++ b/config.sh
@@ -4,11 +4,6 @@
 ARCHIVE_SDIR=pillow-depends-main
 
 # Package versions for fresh source builds
-if [[ -n "$IS_MACOS" ]] && [[ $MACOSX_DEPLOYMENT_TARGET == "10.10" ]]; then
-    LIBXAU_VERSION=1.0.10
-else
-    LIBXAU_VERSION=1.0.11
-fi
 FREETYPE_VERSION=2.12.1
 HARFBUZZ_VERSION=6.0.0
 LIBPNG_VERSION=1.6.39
@@ -75,7 +70,7 @@ function pre_build {
     build_simple xcb-proto 1.15.2 https://xcb.freedesktop.org/dist
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2022.2 https://www.x.org/pub/individual/proto
-        build_simple libXau $LIBXAU_VERSION https://www.x.org/pub/individual/lib
+        build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.4 https://xcb.freedesktop.org/dist
         cp venv/share/pkgconfig/xcb-proto.pc venv/lib/pkgconfig/xcb-proto.pc
     else


### PR DESCRIPTION
Over in https://github.com/python-pillow/Pillow/issues/6862, it turns out that despite #358, users of Pillow 9.4.0 are still having issues on macOS < 11.

@nulano has looked at the [error message](https://github.com/python-pillow/Pillow/issues/6862#issue-1519878587),
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".venv/lib/python3.9/site-packages/PIL/Image.py", line 103, in <module>
    from . import _imaging as core
ImportError: dlopen(.venv/lib/python3.9/site-packages/PIL/_imaging.cpython-39-darwin.so, 2): Library not loaded: @loader_path/libXdmcp.6.dylib
  Referenced from: .venv/lib/python3.9/site-packages/PIL/.dylibs/libxcb.1.1.0.dylib
  Reason: no suitable image found.  Did find:
	.venv/lib/python3.9/site-packages/PIL/.dylibs/libXdmcp.6.dylib: cannot load 'libXdmcp.6.dylib' (load command 0x80000034 is unknown)
	.venv/lib/python3.9/site-packages/PIL/.dylibs/libXdmcp.6.dylib: cannot load 'libXdmcp.6.dylib' (load command 0x80000034 is unknown)
```

and [suggested uninstalling libxdmcp](https://github.com/python-pillow/Pillow/issues/6862#issuecomment-1378193736). I tested this change on my Intel macOS 11 (although not < 11) and found that xcb still worked. Reverting #358 as well, two users - https://github.com/python-pillow/Pillow/issues/6862#issuecomment-1380690430 and https://github.com/python-pillow/Pillow/issues/6862#issuecomment-1381794949 - found that this fixed Pillow on macOS < 11.

So this PR uninstalls libxdmcp and reverts #358