### PR TITLE
Remove existing libwebp on macOS

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -95,6 +95,10 @@ function pre_build {
     build_lcms2
     build_openjpeg
 
+    if [ -n "$IS_MACOS" ]; then
+        # Remove existing libwebp
+        rm /usr/local/lib/libwebp*
+    fi
     ORIGINAL_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
     build_libwebp


### PR DESCRIPTION
Builds have started failing on macOS 64-bit - https://github.com/python-pillow/pillow-wheels/actions/runs/4011551998/jobs/6889238202#step:4:7772
>  raise DelocationError(delocate.delocating.DelocationError: Already planning to copy library with same basename as: libwebp.7.dylib

This PR fixes it by removing /usr/local/lib/libwebp*, as we are already doing for libpng - https://github.com/python-pillow/pillow-wheels/blob/2dac23efcd9c1cc42f18682c0996b3f1cb378ede/config.sh#L90-L93