### PR TITLE
Do not attempt to remove xmlto

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -5,8 +5,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
   # remove lcms2 to fix building openjpeg on arm64
-  # remove xmlto to skip building giflib docs
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php lcms2 xmlto ghostscript
+  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php lcms2 ghostscript
 
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -4,8 +4,8 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # libxdmcp causes an issue on macOS < 11
   # curl from brew requires zstd, use system curl
   # if php is installed, brew tries to reinstall these after installing openblas
-  # remove lcms2 to fix building openjpeg on arm64
-  brew remove --ignore-dependencies webp zstd xz libtiff libxcb libxdmcp curl php lcms2 ghostscript
+  # remove lcms2 and libpng to fix building openjpeg on arm64
+  brew remove --ignore-dependencies webp zstd xz libpng libtiff libxcb libxdmcp curl php lcms2 ghostscript
 
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"

--- a/config.sh
+++ b/config.sh
@@ -87,10 +87,6 @@ function pre_build {
         rm /usr/local/lib/libjpeg.dylib
     fi
     build_tiff
-    if [ -n "$IS_MACOS" ]; then
-        # Remove existing libpng
-        rm /usr/local/lib/libpng*
-    fi
     build_libpng
     build_lcms2
     build_openjpeg


### PR DESCRIPTION
https://github.com/python-pillow/pillow-wheels/blob/2dac23efcd9c1cc42f18682c0996b3f1cb378ede/.github/workflows/build.sh#L8-L9

When attempting to `brew remove xmlto`, an error has started appearing - https://github.com/python-pillow/pillow-wheels/actions/runs/4011551998/jobs/6889238202#step:4:33
> Error: No such keg: /usr/local/Cellar/xmlto

It would seem that `xmlto` is no longer present by default. So this PR changes pillow-wheels to no longer attempt to remove it.

`xmlto` was originally removed in #292, to prevent an error when building giflib.