### PR TITLE
brew install pkg-config

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -7,6 +7,8 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   # remove lcms2 and libpng to fix building openjpeg on arm64
   brew remove --ignore-dependencies webp zstd xz libpng libtiff libxcb libxdmcp curl php lcms2 ghostscript
 
+  brew install pkg-config
+
   if [[ "$PLAT" == "arm64" ]]; then
     export MACOSX_DEPLOYMENT_TARGET="11.0"
   else


### PR DESCRIPTION
macOS builds have started failing in main - https://github.com/python-pillow/pillow-wheels/actions/runs/4227780895/jobs/7342578793#step:4:1793
> configure: error: The pkg-config script could not be found or is too old.  Make sure it is in your PATH or set the PKG_CONFIG environment variable to the full path to pkg-config.

Adding `brew install pkg-config` fixes this.