### PR TITLE
Use --config-settings

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -128,8 +128,7 @@ function pip_wheel_cmd {
         CFLAGS="$CFLAGS --std=c99"  # for Raqm
     fi
     pip wheel $(pip_opts) \
-        --global-option build_ext --global-option --enable-raqm \
-        --global-option --vendor-raqm --global-option --vendor-fribidi \
+        -C raqm=enable -C raqm=vendor -C fribidi=vendor \
         -w $abs_wheelhouse --no-deps .
 }
 
@@ -141,11 +140,7 @@ function run_tests_in_repo {
 
 EXP_CODECS="jpg jpg_2000 libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
-if ([ -n "$IS_MACOS" ] && [[ "$MB_PYTHON_VERSION" == 3.12 ]]); then
-    EXP_FEATURES="libjpeg_turbo transp_webp webp_anim webp_mux xcb"
-else
-    EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
-fi
+EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux xcb"
 
 function run_tests {
     if [ -n "$IS_MACOS" ]; then


### PR DESCRIPTION
Updates to use `--config-settings`, in light of https://github.com/python-pillow/Pillow/pull/7171. This provides fribidi, harfbuzz and raqm features on Python 3.12 for macOS.

This will cause the stable jobs to fail until Pillow 10 is released.