### PR TITLE
Fix py2app "New Mach-O header is too large" error

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -93,6 +93,9 @@ function pre_build {
 
     ORIGINAL_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -O3 -DNDEBUG"
+    if [[ -n "$IS_MACOS" ]]; then
+        CFLAGS="$CFLAGS -Wl,-headerpad_max_install_names"
+    fi
     build_libwebp
     CFLAGS=$ORIGINAL_CFLAGS
 


### PR DESCRIPTION
Resolves https://github.com/python-pillow/Pillow/issues/7250

The issue found that using Pillow with py2app is currently failing with "ValueError: New Mach-O header is too large to relocate". I was able to reproduce this - https://github.com/radarhere/pillow-wheels/actions/runs/5492961738/jobs/10010803436#step:4:9563

I was able to fix this by adding the [standard](https://github.com/ronaldoussoren/py2app/issues/219#issuecomment-1305142378) fix to the libwebp flags - https://github.com/radarhere/pillow-wheels/actions/runs/5493088064