### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,10 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code
-    - build_wheel
+    - libc=${MB_ML_LIBC:-manylinux}
+    - docker_image="quay.io/pypa/${MB_ML_LIBC:-manylinux}${MB_ML_VER}_${PLAT}"
+    - retry docker pull $docker_image
+    - docker run --rm -e BUILD_COMMANDS="build_wheel" -e PYTHON_VERSION="$MB_PYTHON_VERSION" -e MB_PYTHON_VERSION="$MB_PYTHON_VERSION" -e BUILD_COMMIT="HEAD" -e REPO_DIR="$REPO_DIR" -e PLAT="$PLAT" -e MB_ML_VER="$MB_ML_VER" -e MB_ML_LIBC="$libc" -v $PWD:/io -v $HOME:/parent-home $docker_image /io/$MULTIBUILD_DIR/docker_build_wrap.sh
     - ls -l "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
       - REPO_DIR=Pillow
       - BUILD_COMMIT=HEAD
       - PLAT=aarch64
-      - TEST_DEPENDS="pytest pytest-timeout"
+      - TEST_DEPENDS="pytest-timeout"
 
 language: python
 # Default Python version is usually 3.6


### PR DESCRIPTION
The Travis builds have started failing.

The last successful run of Travis was on [July 10](https://app.travis-ci.com/github/python-pillow/pillow-wheels/builds/264378593).
The first failing run on main was on [July 30](https://app.travis-ci.com/github/python-pillow/pillow-wheels/builds/264875420), with the error
> docker: invalid reference format: repository name must be lowercase.

Now, you would think that this is because our repository is named "Pillow".

However, if I switch to ["pillow"](https://github.com/python-pillow/pillow-wheels/commit/cb929e16f1eeeaa5f327ae6b524397570b536b6f), then [the error becomes](https://app.travis-ci.com/github/python-pillow/pillow-wheels/builds/265238481)
> Unable to find image 'pillow:latest' locally

docker appears to be trying to find a docker image named "pillow". What I surmise is happening is that when [`build_wheel` passes"build_wheel Pillow"](https://github.com/multi-build/multibuild/blob/4eb855680308fd279357896dfe0afe59e5c307fa/travis_linux_steps.sh#L28-L45) to [`$build_cmds`](https://github.com/multi-build/multibuild/blob/4eb855680308fd279357896dfe0afe59e5c307fa/travis_linux_steps.sh#L80-L86), `docker` thinks that "Pillow" is the name of the docker image. It has stopped understanding that the space in the middle does not mean that ["BUILD_COMMANDS"](https://github.com/multi-build/multibuild/blob/4eb855680308fd279357896dfe0afe59e5c307fa/travis_linux_steps.sh#L86) is finished, and thinks "Pillow" is a separate argument.

For some reason, this problem doesn't occur in our GitHub Actions builds, or in #367, which continue to pass. So I don't know what has caused `docker` to behave like this in Travis.

I have found that two changes can workaround this problem.
- I experimented with replacing [`build_wheel` in travis.yml](https://github.com/python-pillow/pillow-wheels/blob/cfd5c8a3d2157f4103b41ad182755746213dbcca/.travis.yml#L120) just with `build_multilinux aarch64 build_wheel`. multibuild would work with just "build_wheel" as the `$build_cmds` argument... if the `$REPO_DIR` environment variable was passed through. I created https://github.com/multi-build/multibuild/pull/511 to try and fix that, but it hasn't been merged. Instead, this PR effectively creates a simplified `build_multilinux` in travis.yml.
- Continuing with the fact that `docker` doesn't like spaces in arguments, after [that first change](https://github.com/python-pillow/pillow-wheels/commit/a19a50335a4cc30cddc92580c9d2ec0f14764009), I [get](https://app.travis-ci.com/github/python-pillow/pillow-wheels/builds/265238766)
> Unable to find image 'pytest-timeout:latest' locally

So I have also changed `TEST_DEPENDS` from "pytest pytest-timeout" to "pytest-timeout"