### PR TITLE
Use simpler build_multilinux command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,10 +117,7 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code
-    - libc=${MB_ML_LIBC:-manylinux}
-    - docker_image="quay.io/pypa/${MB_ML_LIBC:-manylinux}${MB_ML_VER}_${PLAT}"
-    - retry docker pull $docker_image
-    - docker run --rm -e BUILD_COMMANDS="build_wheel" -e PYTHON_VERSION="$MB_PYTHON_VERSION" -e MB_PYTHON_VERSION="$MB_PYTHON_VERSION" -e BUILD_COMMIT="HEAD" -e REPO_DIR="$REPO_DIR" -e PLAT="$PLAT" -e MB_ML_VER="$MB_ML_VER" -e MB_ML_LIBC="$libc" -v $PWD:/io -v $HOME:/parent-home $docker_image /io/$MULTIBUILD_DIR/docker_build_wrap.sh
+    - build_multilinux aarch64 build_wheel
     - ls -l "${TRAVIS_BUILD_DIR}/${WHEEL_SDIR}/"
 
 script:


### PR DESCRIPTION
Sequel to #398

https://github.com/multi-build/multibuild/pull/511 has now been merged, correcting a problem in passing the `REPO_DIR` environment variable around in multibuild.

So now, `build_multilinux` doesn't need the repository directory to be passed through by [`$build_cmds`](https://github.com/multi-build/multibuild/blob/509e63a6d8ab4705a500264d396b0e675798b6fc/travis_linux_steps.sh#L80-L86), and `$build_cmds` can just be "build_wheel" instead.

This means our copy of [`build_wheel`](https://github.com/multi-build/multibuild/blob/509e63a6d8ab4705a500264d396b0e675798b6fc/travis_linux_steps.sh#L28-L46) can just become `build_multilinux aarch64 build_wheel`