### PR TITLE
Updated zlib to 1.3

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -18,7 +18,7 @@ else
     GIFLIB_VERSION=5.2.1
 fi
 if [[ -n "$IS_MACOS" ]] || [[ "$MB_ML_VER" != 2014 ]]; then
-    ZLIB_VERSION=1.2.13
+    ZLIB_VERSION=1.3
 else
     ZLIB_VERSION=1.2.8
 fi


### PR DESCRIPTION
zlib 1.3 has been released - https://zlib.net/

You will notice that the stable macOS jobs fail. This is because stable does not yet include https://github.com/python-pillow/Pillow/pull/7344. I half expect there to be a preference to delay merging this, to avoid almost 2 months of the wheels main failing until the next Pillow release updates stable.

You might wonder why the stable Linux jobs aren't failing. It is actually only reporting zlib 1.2.11. I have investigated, and can't find any evidence on the filesystem as to why this would be. In the absence of other options, I conclude it is related to https://github.com/pypa/auditwheel/blob/main/src/auditwheel/policy/manylinux-policy.json - in other words, I suspect this is the highest zlib version allowed for these manylinux wheels.