### PR TITLE
Updated libxcb and dependencies

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -67,7 +67,7 @@ function pre_build {
         BUILD_PREFIX=`dirname $(dirname $(which python))`
         PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig"
     fi
-    build_simple xcb-proto 1.15.2 https://xcb.freedesktop.org/dist
+    build_simple xcb-proto 1.16.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2023.2 https://www.x.org/pub/individual/proto
         build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib

--- a/config.sh
+++ b/config.sh
@@ -71,7 +71,7 @@ function pre_build {
     if [ -n "$IS_MACOS" ]; then
         build_simple xorgproto 2022.2 https://www.x.org/pub/individual/proto
         build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
-        build_simple libpthread-stubs 0.4 https://xcb.freedesktop.org/dist
+        build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
         cp venv/share/pkgconfig/xcb-proto.pc venv/lib/pkgconfig/xcb-proto.pc
     else
         sed s/\${pc_sysrootdir\}// /usr/local/share/pkgconfig/xcb-proto.pc > /usr/local/lib/pkgconfig/xcb-proto.pc

--- a/config.sh
+++ b/config.sh
@@ -24,7 +24,7 @@ else
 fi
 LIBWEBP_VERSION=1.3.1
 BZIP2_VERSION=1.0.8
-LIBXCB_VERSION=1.15
+LIBXCB_VERSION=1.16
 BROTLI_VERSION=1.0.9
 
 if [[ -n "$IS_MACOS" ]] && [[ "$PLAT" == "x86_64" ]]; then
@@ -76,7 +76,7 @@ function pre_build {
     else
         sed s/\${pc_sysrootdir\}// /usr/local/share/pkgconfig/xcb-proto.pc > /usr/local/lib/pkgconfig/xcb-proto.pc
     fi
-    build_simple libxcb $LIBXCB_VERSION https://xcb.freedesktop.org/dist
+    build_simple libxcb $LIBXCB_VERSION https://www.x.org/releases/individual/lib
     if [ -n "$IS_MACOS" ]; then
         BUILD_PREFIX=$ORIGINAL_BUILD_PREFIX
         PKG_CONFIG_PATH=$ORIGINAL_PKG_CONFIG_PATH

--- a/config.sh
+++ b/config.sh
@@ -69,7 +69,7 @@ function pre_build {
     fi
     build_simple xcb-proto 1.15.2 https://xcb.freedesktop.org/dist
     if [ -n "$IS_MACOS" ]; then
-        build_simple xorgproto 2022.2 https://www.x.org/pub/individual/proto
+        build_simple xorgproto 2023.2 https://www.x.org/pub/individual/proto
         build_simple libXau 1.0.11 https://www.x.org/pub/individual/lib
         build_simple libpthread-stubs 0.5 https://xcb.freedesktop.org/dist
         cp venv/share/pkgconfig/xcb-proto.pc venv/lib/pkgconfig/xcb-proto.pc


### PR DESCRIPTION
- xorgproto-2023.2 is now available at https://www.x.org/archive/individual/proto
- libpthread-stubs-0.5 is now available at https://xcb.freedesktop.org/dist
- libxcb 1.16 has been released - https://gitlab.freedesktop.org/xorg/lib/libxcb/-/tags/libxcb-1.16. However, it is not available at https://xcb.freedesktop.org/dist/. I asked about this in https://gitlab.freedesktop.org/xorg/lib/libxcb/-/issues/71, and was told to use https://www.x.org/releases/individual/lib instead, as mentioned in the [announcement](https://lists.x.org/archives/xorg-announce/2023-August/003415.html)
- xcb-proto 1.16.0 has been released - https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/tags/xcb-proto-1.16.0 - but is similarly not available at https://xcb.freedesktop.org/dist/. Instead, the [announcement](https://lists.x.org/archives/xorg-announce/2023-August/003414.html) mentions https://xorg.freedesktop.org/archive/individual/proto