### PR TITLE
Install defusedxml, olefile and pyroma for tests

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -157,6 +157,7 @@ function run_tests {
     if [ -z "$IS_ALPINE" ] && [[ "$MB_PYTHON_VERSION" != 3.12 ]]; then
         python3 -m pip install numpy
     fi
+    python3 -m pip install defusedxml olefile pyroma
 
     curl -fsSL -o pillow-test-images.zip https://github.com/python-pillow/test-images/archive/main.zip
     untar pillow-test-images.zip


### PR DESCRIPTION
https://github.com/python-pillow/pillow-wheels/actions/runs/6087453034/job/16516014212#step:4:7706
> SKIPPED [1] Tests/test_file_fpx.py:7: olefile not installed

https://github.com/python-pillow/pillow-wheels/actions/runs/6087453034/job/16516014212#step:4:7708
> SKIPPED [1] Tests/test_pyroma.py:5: Pyroma not installed

This PR installs those two libraries to improve testing, and also installs defusedxml, to better test the functionality started in https://github.com/python-pillow/Pillow/pull/5565