### PR TITLE
NumPy now supports Python 3.12

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -152,7 +152,7 @@ function run_tests {
         apk add curl fribidi
     else
         apt-get update
-        apt-get install -y curl libfribidi0 unzip
+        apt-get install -y curl libfribidi0 libopenblas-dev pkg-config unzip
     fi
     if [ -z "$IS_ALPINE" ]; then
         python3 -m pip install numpy

--- a/config.sh
+++ b/config.sh
@@ -148,6 +148,7 @@ EXP_FEATURES="fribidi harfbuzz libjpeg_turbo raqm transp_webp webp_anim webp_mux
 function run_tests {
     if [ -n "$IS_MACOS" ]; then
         brew install fribidi
+        export PKG_CONFIG_PATH="/usr/local/opt/openblas/lib/pkgconfig"
     elif [ -n "$IS_ALPINE" ]; then
         apk add curl fribidi
     else

--- a/config.sh
+++ b/config.sh
@@ -154,7 +154,7 @@ function run_tests {
         apt-get update
         apt-get install -y curl libfribidi0 unzip
     fi
-    if [ -z "$IS_ALPINE" ] && [[ "$MB_PYTHON_VERSION" != 3.12 ]]; then
+    if [ -z "$IS_ALPINE" ]; then
         python3 -m pip install numpy
     fi
     python3 -m pip install defusedxml olefile pyroma


### PR DESCRIPTION
With the release of NumPy 1.26.0, NumPy supports Python 3.12 - https://github.com/numpy/numpy/releases/tag/v1.26.0

This also fixes the failures that have [started happening on main](https://github.com/python-pillow/pillow-wheels/actions/runs/6217841175) due to [an absence of PyPy3.10 wheels for the NumPy release.](https://github.com/numpy/numpy/issues/24728)