### PR TITLE
Test NumPy on Alpine for Python >= 3.9

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -155,7 +155,7 @@ function run_tests {
         apt-get update
         apt-get install -y curl libfribidi0 libopenblas-dev pkg-config unzip
     fi
-    if [ -z "$IS_ALPINE" ]; then
+    if [ -z "$IS_ALPINE" ] || [[ "$MB_PYTHON_VERSION" != 3.8 ]]; then
         python3 -m pip install numpy
     fi
     python3 -m pip install defusedxml olefile pyroma


### PR DESCRIPTION
I tested installing NumPy on Alpine Linux - https://github.com/radarhere/pillow-wheels/commit/ff1277b25a0bb1f841daf64a435cb2e84752ed3e / https://github.com/radarhere/pillow-wheels/actions/runs/6231540267 - and found that it installs successfully for Python >= 3.9.

I imagine this is due to NumPy's new build system, which is not released for Python 3.8.